### PR TITLE
Adding lintserver for files. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ You just need to put in the root symbol for a parametric type, for example
 
 ## Lintserver feature - experimental
 
-Lint now contains a function that such that Julia starts listening on a given port and returning lint messages to the connection.
+Lint now contains a function `lintesrver` making Julia start listening on a given port and returning lint messages to the connection.
 
 It has been tried out and the following example works on OS X, suggestions are welcome for other systems.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ You just need to put in the root symbol for a parametric type, for example
 
 ## Lintserver feature - experimental
 
-Lint now contains a function `lintesrver` making Julia start listening on a given port and returning lint messages to the connection.
+Lint now contains a function `linteserver` making Julia start listening on a given port and returning lint messages to the connection.
 
 It has been tried out and the following example works on OS X, suggestions are welcome for other systems.
 

--- a/README.md
+++ b/README.md
@@ -240,3 +240,21 @@ push!( ctx.callstack[end].types, roottypesymbol )
 ```
 You just need to put in the root symbol for a parametric type, for example
 `:A` for `A{T<:Any}`.
+
+## Lintserver feature - experimental
+
+Lint now contains a function that such that Julia starts listening on a given port and returning lint messages to the connection.
+
+It has been tried out and the following example works on OS X, suggestions are welcome for other systems.
+
+### Example
+First open julia and do:
+````{julia}
+using Lint
+lintserver(2222)
+````
+Then, assuming you have a file named `test.jl` in your documents to be linted, from bash you can do:
+````{bash}
+(echo "~/Documents/test.jl"; sleep 2) | nc -w 2 localhost 2222
+````
+For the first time you might have to do that multiple times because the linting functions are being imported and compiled.

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -6,7 +6,7 @@ using Base.Meta
 using Compat
 
 export LintMessage, LintContext, LintStack
-export lintfile, lintstr, lintpkg, @lintpragma
+export lintfile, lintstr, lintpkg, lintserver, @lintpragma
 export test_similarity_string
 
 const SIMILARITY_THRESHOLD = 10.0
@@ -242,6 +242,30 @@ function lintexpr( ex::Any, ctx::LintContext )
                 registersymboluse( sube, ctx )
             end
         end
+    end
+end
+
+function lintserver(port)
+    server = listen(port)
+    while true
+      conn = accept(server)
+      @async begin
+        try
+          while true
+            line = readline(conn)
+            println(typeof(line))
+            println(ispath(strip(line)))
+            println(strip(line))
+            m = lintfile(strip(line), returnMsgs = true)
+            for i in m
+                write(conn, string(i))
+                write(conn, "\n")
+            end
+          end
+        catch err
+          print("connection ended with error $err")
+        end
+      end
     end
 end
 

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -253,14 +253,22 @@ function lintserver(port)
         try
           while true
             line = readline(conn)
+            
             println(typeof(line))
             println(ispath(strip(line)))
             println(strip(line))
-            m = lintfile(strip(line), returnMsgs = true)
+            
+            if ispath(strip(line))
+                m = lintfile(strip(line), returnMsgs = true)
+            else
+                error("The string is not a file.")
+            end
+            
             for i in m
                 write(conn, string(i))
                 write(conn, "\n")
             end
+            
           end
         catch err
           print("connection ended with error $err")

--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -6,8 +6,8 @@ type LintMessage
     message :: String
 end
 
-import Base.show
-function Base.show( io::IO, m::LintMessage )
+import Base.string
+function string( m::LintMessage )
     s = @sprintf( "%s:%d ", m.file, m.line )
     s = s * @sprintf( "[%-15s] ", m.scope )
     arr = [ "INFO", "WARN", "ERROR", "FATAL" ]
@@ -21,7 +21,12 @@ function Base.show( io::IO, m::LintMessage )
             s = s * "\n" *  (" " ^ ident) * l
         end
     end
-    print( io, s )
+    return s
+end
+
+import Base.show
+function Base.show( io::IO, m::LintMessage )
+    print( io, string(m) )
 end
 
 import Base.isless


### PR DESCRIPTION
## Main changes

- Added string method for the lint message for printing, it is basically former show method.
- The show method has been shortened.
- Added linetserver, a function accepting a number which creates an asynchronous server that listens for names of files to lint.

Useful mainly because the firing up julia and linter takes about 10 seconds and even compiling from source with `userimg.jl` does not help. (Unsure why as the code for Lint is pure julia...)

## Example:
First open julia and do:
````{julia}
using Lint
lintserver(2222)
````
Then from bash you can do (for the first time you might have to do that multiple times because the linting functions are being imported and compiled):
````{bash}
(echo "~/Documents/test.jl"; sleep 2) | nc -w 2 localhost 2222
````

## Future
One might create DSL for other linting functions, such as: "FILE .... " would take a file path and run `lintfile`, "BEGIN CHUNK" would read multiple lines until "END CHUNK" and run other linting function on this. But I did this as more of a hack, I am not a seasoned developer to be able to do such substantial work, mainly because of lack of knowledge.