### PR TITLE
Warning: error initializing module Lint: Base.TypeError(func=:filter, co...

### DIFF
--- a/src/knownsyms.jl
+++ b/src/knownsyms.jl
@@ -22,11 +22,13 @@ function cacheknownsyms()
         try
             ok = isa( eval( Base, x ), DataType )
         end
+        ok
     end)
     union!( knowntypes, filter( names( Core ) ) do x
         ok = false
         try
             ok = isa( eval( Core, x ), DataType )
         end
+        ok
     end)
 end


### PR DESCRIPTION
...ntext="if", expected=Bool, got=nothing)

Removed this error, which only occurs in 0.4. 
It doesn't give any line number or anything, so we should probably also open an issue at julia.