### PR TITLE
Added test for incomplete expressions

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -242,6 +242,8 @@ function lintexpr( ex::Any, ctx::LintContext )
     elseif ex.head in [ :(&&), :(||) ]
         lintboolean( ex.args[1], ctx )
         lintexpr( ex.args[2], ctx ) # do not enforce boolean. e.g. b==1 || error( "b must be 1!" )
+    elseif ex.head == :incomplete
+        msg(ctx, 3, ex.args[1])
     else
         for sube in ex.args
             if typeof(sube)== Expr


### PR DESCRIPTION
Currently, incomplete expressions are ignored. For instance, a module missing the "end" keyword reports no errors at all.

Examples:
    julia> lintstr("module test; if true; end")
    julia> lintstr("2 +")