### PR TITLE
Fix deprecated syntax "Dict{} (" -> "Dict{}("

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -1,5 +1,5 @@
 commoncollections = DataType[ Array, AbstractArray, BitArray, Set, Associative ]
-commoncollmethods = Dict{ Symbol, Set{ DataType }} ()
+commoncollmethods = Dict{ Symbol, Set{ DataType }}()
 
 function initcommoncollfuncs()
     global commoncollmethods, commoncollections


### PR DESCRIPTION
Fixes
WARNING: deprecated syntax "Dict{Symbol,Set{DataType}} (" at Lint/src/functions.jl:2.
Use "Dict{Symbol,Set{DataType}}(" instead.