### PR TITLE
RFC: Improve lintserver

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -290,14 +290,14 @@ function lintserver(port)
             # Build context
             ctx = LintContext()
             ctx.file = file
-            if ispath( file )
-                ctx.path = dirname( file )
+            if ispath(file)
+                ctx.path = dirname(file)
             end
             # Lint code
-            msgs = lintstr( code, ctx )
+            msgs = lintstr(code, ctx)
             # Process messages
-            clean_messages!( msgs )
-            display_messages( msgs )
+            clean_messages!(msgs)
+            display_messages(msgs)
             # Write response to socket
             for i in msgs
                 write(conn, string(i))

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -272,12 +272,9 @@ function lintserver(port)
             file = strip(readline(conn))
             println("file: ", file)
             code_len = parse(Int, strip(readline(conn)))
-            println("code length: ", code_len)
-            code = ""
-            while length(code) < code_len
-                code = string(code, readline(conn))
-            end
-            println("code received: ", length(code))
+            println("Code bytes: ", code_len)
+            code = utf8(readbytes(conn, code_len))
+            println("Code received")
             # Build context
             ctx = LintContext()
             ctx.file = file

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -48,13 +48,11 @@ end
 
 function lintfile{T<:AbstractString}( file::T; returnMsgs::Bool = false )
     if !ispath( file )
-        throw( "no such file exists")
+        throw( "no such file exists" )
     end
 
-    ctx = LintContext()
-    ctx.file = file
-    ctx.path = dirname( file )
-    str = open(readall, file)
+    ctx = LintContext( file )
+    str = open( readall, file )
 
     msgs = lintstr( str, ctx )
 
@@ -288,11 +286,7 @@ function lintserver(port)
             code = utf8(readbytes(conn, code_len))
             println("Code received")
             # Build context
-            ctx = LintContext()
-            ctx.file = file
-            if ispath(file)
-                ctx.path = dirname(file)
-            end
+            ctx = LintContext(file)
             # Lint code
             msgs = lintstr(code, ctx)
             # Process messages

--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -158,6 +158,15 @@ type LintContext
             Any[ LintStack( true ) ], LintMessage[], _ -> true, LintIgnoreState() )
 end
 
+function LintContext(file::AbstractString)
+    ctx = LintContext()
+    ctx.file = file
+    if ispath(file)
+        ctx.path = dirname(file)
+    end
+    return ctx
+end
+
 function pushcallstack( ctx::LintContext )
     push!( ctx.callstack, LintStack() )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,7 @@ include( "undeclare.jl" )
 include( "unusedvar.jl")
 include( "using.jl")
 include( "versions.jl" )
+include( "server.jl" )
 if VERSION >= v"0.4.0-dev+1444"
     include( "stagedfuncs.jl")
 end

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,0 +1,24 @@
+# find a good port
+conn = listenany(2228)
+close(conn[2])
+port = conn[1]
+
+@async lintserver(port)
+sleep(1) #let sever start
+
+
+conn = connect(port)
+write(conn, "empty\n")
+write(conn, "1\n")
+write(conn, "\n")
+
+@test readline(conn) == "\n"
+
+
+conn = connect(port)
+write(conn, "undeclared_symbol\n")
+write(conn, "4\n")
+write(conn, "bad\n")
+
+@test contains(readline(conn), "Use of undeclared symbol bad\n")
+@test readline(conn) == "\n"

--- a/test/server.jl
+++ b/test/server.jl
@@ -3,7 +3,7 @@ conn = listenany(2228)
 close(conn[2])
 port = conn[1]
 
-@async lintserver(port)
+server = @async lintserver(port)
 sleep(1) #let sever start
 
 
@@ -22,3 +22,8 @@ write(conn, "bad\n")
 
 @test contains(readline(conn), "Use of undeclared symbol bad\n")
 @test readline(conn) == "\n"
+
+
+try # close the server
+    Base.throwto(server, InterruptException())
+end


### PR DESCRIPTION
Change lintserver to accept code to avoid having to use temp files for unsaved changes.
Change protocol to:
 - accept a file name, the amount of code in bytes then the actual code.
 - reply with the lint messages sending a empty line to indicated no more messages.