### PR TITLE
Fix exception when passing non expr as keyword arg

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -522,10 +522,12 @@ function lintfunctioncall( ex::Expr, ctx::LintContext )
                     elseif isexpr( kw, :(=>) )
                         lintexpr( kw.args[1], ctx )
                         lintexpr( kw.args[2], ctx )
-                    elseif length(kw.args) != 2
-                        msg( ctx, 2, "unknown keyword pattern " * string(kw))
-                    else
+                    elseif isa(kw, Expr) && length(kw.args) == 2
                         lintexpr( kw.args[2], ctx )
+                    elseif isa(kw, Symbol)
+                        lintexpr( kw, ctx )
+                    else
+                        msg( ctx, 2, "unknown keyword pattern " * string(kw))
                     end
                 end
             elseif isexpr( ex.args[i], :kw )

--- a/test/funcall.jl
+++ b/test/funcall.jl
@@ -348,3 +348,16 @@ if VERSION >= v"0.4"
     msgs = lintstr(s)
     @test( isempty( msgs ) )
 end
+
+s="""
+a = (:a, 1)
+f(; a)
+"""
+msgs = lintstr(s)
+@test( isempty( msgs ) )
+
+s = """
+f(; 2)
+"""
+msgs = lintstr(s)
+@test contains( msgs[1].message, "unknown keyword pattern" )


### PR DESCRIPTION
``` julia
julia> lintstr("f(; a)")
ERROR: type Symbol has no field args
 in lintfunctioncall at /Users/michaelklassen/.julia/v0.4/Lint/src/functions.jl:525
 in lintexpr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:149
 in lintstr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:106
 in lintstr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:79
```