### PR TITLE
Convert to string before utf8 if not guaranteed to be string or symbol

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -105,7 +105,7 @@ function lintfunction( ex::Expr, ctx::LintContext; ctorType = Symbol( "" ), isst
     ctx.scope = string(fname)
     if fname != Symbol( "" ) && !contains( ctx.file, "deprecate" )
         isDeprecated = functionIsDeprecated( ex.args[1] )
-        if isDeprecated != nothing && !pragmaexists( "Ignore deprecated " * utf8( fname ), ctx )
+        if isDeprecated != nothing && !pragmaexists( "Ignore deprecated $fname", ctx )
             msg( ctx, 2, isDeprecated.message * "\nSee: deprecated.jl " * string( isDeprecated.line ) )
         end
     end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -150,7 +150,7 @@ function lintglobal( ex::Expr, ctx::LintContext )
         elseif isexpr( sym, ASSIGN_OPS )
             lintassignment( sym, sym.head, ctx; isGlobal=true )
         else
-            msg( ctx, 0, "unknown global pattern " * utf8(sym))
+            msg( ctx, 0, "unknown global pattern " * string(sym))
         end
     end
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -150,7 +150,7 @@ function lintglobal( ex::Expr, ctx::LintContext )
         elseif isexpr( sym, ASSIGN_OPS )
             lintassignment( sym, sym.head, ctx; isGlobal=true )
         else
-            msg( ctx, 0, "unknown global pattern $sym")
+            msg( ctx, 2, "unknown global pattern $sym")
         end
     end
 end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -150,7 +150,7 @@ function lintglobal( ex::Expr, ctx::LintContext )
         elseif isexpr( sym, ASSIGN_OPS )
             lintassignment( sym, sym.head, ctx; isGlobal=true )
         else
-            msg( ctx, 0, "unknown global pattern " * string(sym))
+            msg( ctx, 0, "unknown global pattern $sym")
         end
     end
 end
@@ -238,11 +238,11 @@ function lintassignment( ex::Expr, assign_ops::Symbol, ctx::LintContext; islocal
 
         if VERSION < v"0.4.0-dev+4139"
             if rhstype <: Tuple && length( rhstype ) != tuplelen
-                msg( ctx, 0, "Iteration generates tuples of "*utf8(rhstype)*". N of variables used: "* utf8( string(tuplelen) ) )
+                msg( ctx, 0, "Iteration generates tuples of $rhstype. N of variables used: $tuplelen" )
             end
         else
             if rhstype <: Tuple && length( rhstype.parameters ) != tuplelen
-                msg( ctx, 0, "Iteration generates tuples of "*string(rhstype)*". N of variables used: "* string( tuplelen ) )
+                msg( ctx, 0, "Iteration generates tuples of $rhstype. N of variables used: $tuplelen" )
             end
         end
     end
@@ -250,13 +250,13 @@ function lintassignment( ex::Expr, assign_ops::Symbol, ctx::LintContext; islocal
     if VERSION < v"0.4.0-dev+4139"
         if typeof( rhstype ) != Symbol && rhstype <: Tuple && length( rhstype ) != tuplelen && !isForLoop
             if length( syms ) > 1
-                msg( ctx, 2, "RHS is a tuple of "*utf8(rhstype)*". N of variables used: "* string( tuplelen ) )
+                msg( ctx, 2, "RHS is a tuple of $rhstype. N of variables used: $tuplelen" )
             end
         end
     else
         if typeof(rhstype) != Symbol && rhstype <: Tuple && length( rhstype.parameters ) != tuplelen && !isForLoop
             if tuplelen > 1
-                msg( ctx, 2, "RHS is a tuple of "*string(rhstype)*". N of variables used: "* string( tuplelen ) )
+                msg( ctx, 2, "RHS is a tuple of $rhstype. N of variables used: $tuplelen" )
             end
         end
     end

--- a/test/globals.jl
+++ b/test/globals.jl
@@ -54,3 +54,8 @@ end
 """
 msgs = lintstr(s)
 @test( contains(msgs[1].message, "expected assignment after \\\"const\\\"") )
+s = """
+global 5
+"""
+msgs = lintstr(s)
+@test( contains(msgs[1].message, "unknown global pattern") )


### PR DESCRIPTION
``` julia
julia> lintstr("global 5")
ERROR: MethodError: `convert` has no method matching convert(::Type{UTF8String}, ::Int64)
This may have arisen from a call to the constructor UTF8String(...),
since type constructors fall back to convert methods.
Closest candidates are:
  call{T}(::Type{T}, ::Any)
  convert(::Type{UTF8String}, ::UTF8String)
  convert(::Type{UTF8String}, ::ASCIIString)
  ...
 in utf8 at unicode/utf8.jl:233
 in lintglobal at /Users/michaelklassen/.julia/v0.4/Lint/src/variables.jl:153
 in lintexpr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:155
 in lintstr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:106
 in lintstr at /Users/michaelklassen/.julia/v0.4/Lint/src/Lint.jl:79
```