### PR TITLE
Fix linting of generic function without methods

### DIFF
--- a/src/functions.jl
+++ b/src/functions.jl
@@ -53,12 +53,12 @@ end
 # a constructor for a type. We would check
 # * if the function name matches the type name
 function lintfunction( ex::Expr, ctx::LintContext; ctorType = Symbol( "" ), isstaged=false )
-    if ex.args[1].args[1]==:eval # extending eval(m,x) = ... in module. don't touch it.
+    if length(ex.args) == 1 && typeof(ex.args[1]) == Symbol
+        # generic function without methods
         return
     end
 
-    if length(ex.args) == 1 && typeof(ex.args[1]) == Symbol
-        # generic function without methods
+    if ex.args[1].args[1]==:eval # extending eval(m,x) = ... in module. don't touch it.
         return
     end
 

--- a/test/funcall.jl
+++ b/test/funcall.jl
@@ -323,6 +323,12 @@ msgs = lintstr(s)
 @test( isempty( msgs ) )
 
 s = """
+function f end
+"""
+msgs = lintstr(s)
+@test isempty( msgs )
+
+s = """
 a = :b
 f(; a => 1 )
 """


### PR DESCRIPTION
This kind of declaration of a function with no methods is allowed by Julia:

```julia
function f end
```

There are many legitimate reasons why this would be useful. However, Lint.jl currently crashes when linting this kind of function. From what I can tell, this was handled correctly once upon a time, since there is code to handle it. However, a fix for another bug has made that code useless. This commit restores that code to the right location. It adds no code except for a single regression test.