### PR TITLE
Fix incomplete Dict linting

### DIFF
--- a/src/dict.jl
+++ b/src/dict.jl
@@ -41,9 +41,9 @@ function lintdict4( ex::Expr, ctx::LintContext )
                     end
                 end
             end
-
-            lintexpr( a.args[2], ctx )
         end
+
+        lintexpr( a, ctx )
     end
 
     if typed

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -5,6 +5,14 @@ msgs = lintstr( s )
 @test( contains( msgs[1].message, "String uses * to concat"))
 
 s = """
+function f(x)
+    Dict("a" + "b" => x)
+end
+"""
+msgs = lintstr(s)
+@test contains( msgs[1].message, "String uses * to concat" )
+
+s = """
 s = String(1)
 """
 msgs = lintstr( s )

--- a/test/unusedvar.jl
+++ b/test/unusedvar.jl
@@ -53,3 +53,11 @@ end
 """
 msgs = lintstr(s)
 @test( isempty( msgs ) )
+
+s = """
+function f(x...)
+    Dict(x...)
+end
+"""
+msgs = lintstr(s)
+@test isempty( msgs )


### PR DESCRIPTION
When linting `Dict` constructors, Lint does not lint the keys, or raw pairs. This causes both false positives:

```julia
function a(x)
    Dict(x => 1)
end
```
which results in a spurious "INFO   Argument declared but not used: x", and false negatives:

```julia
function a()
    Dict("a" + "b" => 1)
end
```
which results in no error despite the string concatenation problem.

This commit fixes both problems and adds regression tests for both cases.