### PR TITLE
Define show() instead of string()

### DIFF
--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -6,30 +6,20 @@ type LintMessage
     message :: UTF8String
 end
 
-import Base.string
-function string( m::LintMessage )
-    s = @sprintf( "%s:%d ", m.file, m.line )
-    s = s * @sprintf( "[%-15s] ", m.scope )
+function Base.show( io::IO, m::LintMessage )
+    s  = @sprintf( "%s:%d ", m.file, m.line )
+    s *= @sprintf( "[%-15s] ", m.scope )
     arr = [ "INFO", "WARN", "ERROR", "FATAL" ]
-    s = s * @sprintf( "%-5s  ", arr[ m.level+1 ] )
+    s *= @sprintf( "%-5s  ", arr[ m.level+1 ] )
+    print( io, s )
     ident = min( 60, length(s) )
     lines = split(m.message, "\n")
-    for (i,l) in enumerate(lines)
-        if i==1
-            s = s * l
-        else
-            s = s * "\n" *  (" " ^ ident) * l
-        end
+    print( io, lines[1] )
+    for l in lines[2:end]
+        print( io, "\n", " " ^ ident, l )
     end
-    return s
 end
 
-import Base.show
-function Base.show( io::IO, m::LintMessage )
-    print( io, string(m) )
-end
-
-import Base.isless
 function Base.isless( m1::LintMessage, m2::LintMessage )
     if m1.file != m2.file
         return isless(m1.file, m2.file)


### PR DESCRIPTION
I think it is more usual to override `show` than to override `string`, since there are 119 methods for `show` but only 14 for `string`. Overriding `show` gives `string` for free, so this reduces the amount of code. There should not be any functional change.

I also deleted the `import Base.show` and `import Base.isless` statements because they were not doing anything, since the methods were defined using the fully-qualified names.

Apologies for the many pull requests; I am trying to get `Currencies.jl` to pass with Lint and there are a few more false positives to sort through. This change is not related to the false positives but I think the simplification is nice.