### PR TITLE
Better curly linting

### DIFF
--- a/src/curly.jl
+++ b/src/curly.jl
@@ -3,25 +3,41 @@
 # declaring a parametric function or parametric type are separately
 # considered in lintfunction and linttype, respectively.
 
+# contracts for common collections / type parametrized types
+# TODO: Can we be more specific here? What about detecting contract?
+const CURLY_CONTRACTS = Dict{Symbol, Any}(
+    :Array  => (DataType, Integer),
+    :Dict   => (DataType, DataType),
+    :Matrix => (DataType,),
+    :Set    => (DataType,),
+    :Type   => (DataType,),
+    :Val    => (Any,),
+    :Vector => (DataType,))
+
 function lintcurly( ex::Expr, ctx::LintContext )
-    if ex.args[1] == :Ptr && length(ex.args)==2 && ex.args[2] == :Void
+    head = ex.args[1]
+    if head == :Ptr && length(ex.args)==2 && ex.args[2] == :Void
         return
     end
+    contract = get(CURLY_CONTRACTS, head, nothing)
     for i = 2:length( ex.args )
         a = ex.args[i]
         if isexpr( a, :parameters ) # only used for Traits.jl, AFAIK
             continue # grandfathered. We worry about linting this later
         elseif isexpr( a, :($) )
             continue # grandfathered
-        elseif typeof( a ) == QuoteNode || isexpr( a, :quote )
-            if ex.args[1] != :Val
-                msg( ctx, 0, "Probably illegal use of " * string(a) * " inside curly.")
-            end
         else
             t = guesstype( a, ctx )
-            if t == Symbol || t != Any && t != () && typeof( t ) != DataType &&
-                !( typeof( t ) <: Tuple && all( x->typeof( x ) == DataType, t ) ) && !( t <: Integer )
+            if !(t == DataType || t == Symbol || isbits(t) || t == Any)
                 msg( ctx, 1, "Probably illegal use of " * string(a) * " inside curly.")
+            elseif contract != nothing
+                if i - 1 > length(contract)
+                    msg( ctx, 2, "Too many type parameters for $head." )
+                elseif !(t <: contract[i - 1] || t == Any)
+                    msg( ctx, 2, """
+                    $t can't be #$(i-1) type parameter for $head;
+                    it should be of type $(contract[i-1]).""" )
+                end
             end
             lintexpr( a, ctx )
         end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -503,10 +503,7 @@ function lintfunctioncall( ex::Expr, ctx::LintContext )
 
         en = length(ex.args)
 
-        if isexpr( ex.args[1], :curly )
-            # Dict{Symbol, Int}
-            lintexpr( ex.args[1], ctx )
-        elseif isexpr( ex.args[1], :(.))
+        if isexpr( ex.args[1], :(.))
             lintexpr( ex.args[1], ctx )
         elseif typeof( ex.args[1] ) == Symbol
             push!( ctx.callstack[end].calledfuncs, ex.args[1] )

--- a/test/curly.jl
+++ b/test/curly.jl
@@ -2,26 +2,44 @@ s = """
 a = Dict{ :Symbol, Any}
 """
 msgs = lintstr(s)
-@test( contains( msgs[1].message, "Probably illegal use of" ) )
+@test( contains( msgs[1].message, "type parameter for Dict" ) )
 
 s = """
 a = Dict{ :Symbol, Any}()
 """
 msgs = lintstr(s)
-@test( contains( msgs[1].message, "Probably illegal use of" ) )
+@test( contains( msgs[1].message, "type parameter for Dict" ) )
+
+s = """
+a = Set{ Tuple{ Int, Int } }()
+"""
+msgs = lintstr(s)
+@test( isempty( msgs ) )
 
 s = """
 a = Set{ ( Int, Int ) }()
 """
 msgs = lintstr(s)
-@test( isempty( msgs ) )
+@test contains( msgs[1].message, "Probably illegal use of" )
 
 s = """
 b = :Symbol
 a = Dict{ b, Any}()
 """
 msgs = lintstr(s)
-@test( contains( msgs[1].message, "Probably illegal use of" ) )
+@test( contains( msgs[1].message, "type parameter for Dict" ) )
+
+s = """
+a = Array{2, Int64}()
+"""
+msgs = lintstr(s)
+@test contains( msgs[1].message, "type parameter for Array" )
+
+s = """
+a = Array{Int64, 5, 5}()
+"""
+msgs = lintstr(s)
+@test contains( msgs[1].message, "Too many type parameters" )
 
 s = """
 a = Ptr{ Void }
@@ -34,4 +52,3 @@ s = """
 """
 msgs = lintstr( s )
 @test( isempty( msgs ) )
-


### PR DESCRIPTION
This patch addresses several issues with the old curly linting:

 * Fixed false positive: `b = :sym; v = Val{b}`
 * Fixed false negative (since 0.4): `Set{(Int, Int)}()` no longer works, but no lint error is raised
 * Catch problems like `Array{2, Int}()`
 * Catch problems like `Array{Int, 2, 2}()`
 * Fixed double linting: `Set{a}()` used to give two undeclared variable errors, even though only one should be raised.

The first change is probably the most important. Julia allows any bitstype to be used as a type parameter, as well as symbols, and this change prevents that from throwing lint errors.