### PR TITLE
Fix bugs with latest master

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.7
+Compat 0.8

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -212,7 +212,7 @@ function lintcomparison(ex::Expr, ctx::LintContext)
                        !(lefttype <: righttype) && !(righttype <: lefttype)
                     problem = true
                 end
-                if problem && !pragmaexists(utf8("Ignore incompatible type comparison"), ctx)
+                if problem && !pragmaexists("Ignore incompatible type comparison", ctx)
                     msg(ctx, :W542, "comparing apparently incompatible types " *
                         "(#$(i>>1)) LHS:$(lefttype) RHS:$(righttype)")
                 end
@@ -261,17 +261,9 @@ function lintcomprehension(ex::Expr, ctx::LintContext; typed::Bool = false)
             if isexpr(ex.args[1], :(=>))
                 declktype = ex.args[1].args[1]
                 declvtype = ex.args[1].args[2]
-                if declktype == TopNode(:Any) && declvtype == TopNode(:Any) && VERSION < v"0.4-"
-                    msg(ctx, :I484, "untyped dictionary {a=>b for (a,b) in c}, may " *
-                        "be deprecated by Julia 0.4. Use (Any=>Any)[a=>b for (a,b) in c]")
-                end
             end
         else
             declvtype = ex.args[1]
-            if declvtype == TopNode(:Any) && VERSION < v"0.4-"
-                msg(ctx, :I485, "untyped dictionary {a for a in c}, may be " *
-                    "deprecated by Julia 0.4. Use (Any)[a for a in c]")
-            end
         end
     end
 

--- a/src/dict.jl
+++ b/src/dict.jl
@@ -57,7 +57,7 @@ function lintdict4(ex::Expr, ctx::LintContext)
         end
     else
         # if the expression is explicitly (Any=>Any)[:a => 1], then it'd be
-        #   :Any=>:Any, not TopNode(:Any)=>TopNode(:Any)
+        #   :Any=>:Any, not GlobalRef(Base, :Any)=> GlobalRef(Base, :Any)
         if !in(Any, ktypes) && length(ktypes) == 1 && !in(Any, vtypes) && length(vtypes) == 1
             msg(ctx, :I581, "there is only 1 key type && 1 value type. Use explicit " *
                 "Dict{K,V}() for better performances")

--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -1,10 +1,10 @@
 type LintMessage
-    file    :: UTF8String
+    file    :: Compat.UTF8String
     code    :: Symbol #[E|W|I][1-9][1-9][1-9]
-    scope   :: UTF8String
+    scope   :: Compat.UTF8String
     line    :: Int
-    variable:: UTF8String
-    message :: UTF8String
+    variable:: Compat.UTF8String
+    message :: Compat.UTF8String
 end
 
 type VarInfo
@@ -31,7 +31,7 @@ type LintStack
     localusedvars :: Array{Set{Symbol}, 1}
     usedvars      :: Set{Symbol}
     oosvars       :: Set{Symbol}
-    pragmas       :: Dict{UTF8String, PragmaInfo} # the boolean denotes if the pragma has been used
+    pragmas       :: Dict{Compat.UTF8String, PragmaInfo} # the boolean denotes if the pragma has been used
     calledfuncs   :: Set{Symbol}
     inModule      :: Bool
     moduleName    :: Any
@@ -42,7 +42,7 @@ type LintStack
     functions     :: Set{Any}
     modules       :: Set{Any}
     macros        :: Set{Any}
-    linthelpers   :: Dict{UTF8String, Any}
+    linthelpers   :: Dict{Compat.UTF8String, Any}
     data          :: Dict{Symbol, Any}
     isTop         :: Bool
     LintStack() = begin
@@ -54,7 +54,7 @@ type LintStack
             [Set{Symbol}()],
             Set{Symbol}(),
             Set{Symbol}(),
-            Dict{UTF8String, Bool}(), #pragmas
+            Dict{Compat.UTF8String, Bool}(), #pragmas
             Set{Symbol}(),
             false,
             Symbol(""),
@@ -65,7 +65,7 @@ type LintStack
             Set{Any}(),
             Set{Any}(),
             Set{Any}(),
-            Dict{UTF8String, Any}(),
+            Dict{Compat.UTF8String, Any}(),
             Dict{Symbol, Any}(),
             false,
            )
@@ -94,12 +94,12 @@ end
 const LINT_IGNORE_DEFAULT = LintIgnore[LintIgnore(:W651, "")]
 
 type LintContext
-    file         :: UTF8String
+    file         :: Compat.UTF8String
     line         :: Int
     lineabs      :: Int
-    scope        :: UTF8String # usually the function name
+    scope        :: Compat.UTF8String # usually the function name
     isstaged     :: Bool
-    path         :: UTF8String
+    path         :: Compat.UTF8String
     included     :: Array{AbstractString,1} # list of files included
     globals      :: Dict{Symbol,Any}
     types        :: Dict{Symbol,Any}

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -108,7 +108,11 @@ function lintimport(ex::Expr, ctx::LintContext; all::Bool = false)
             )
             eval(Main, ex)
             lastpart = ex.args[end]
-            m = eval(Main, parse(join(ex.args, ".")))
+            if length(ex.args) == 2
+                m = eval(Main, :($(ex.args[1]).$(ex.args[2])))
+            else
+                m = eval(Main, ex.args[1])
+            end
         end
     catch er
         problem = true
@@ -125,4 +129,3 @@ function lintimport(ex::Expr, ctx::LintContext; all::Bool = false)
         end
     end
 end
-

--- a/src/pragma.jl
+++ b/src/pragma.jl
@@ -45,7 +45,7 @@ function lintlintpragma(ex::Expr, ctx::LintContext)
     end
 end
 
-function pragmaexists(s::UTF8String, ctx::LintContext; deep=true)
+function pragmaexists(s::Compat.UTF8String, ctx::LintContext; deep=true)
     iend = deep ? 1 : length(ctx.callstack)
     for i in length(ctx.callstack):-1:iend
         if haskey(ctx.callstack[i].pragmas, s)
@@ -56,4 +56,4 @@ function pragmaexists(s::UTF8String, ctx::LintContext; deep=true)
     return false
 end
 
-pragmaexists(s::ASCIIString, ctx::LintContext; deep = true) = pragmaexists(utf8(s), ctx; deep = deep)
+pragmaexists(s::AbstractString, ctx::LintContext; deep = true) = pragmaexists(Compat.UTF8String(s), ctx; deep = deep)

--- a/src/types.jl
+++ b/src/types.jl
@@ -87,7 +87,7 @@ function linttype(ex::Expr, ctx::LintContext)
             ctx.line = def.line-1
         elseif typeof(def) == Symbol
             # it means Any, probably not a very efficient choice
-            if !pragmaexists(utf8("Ignore untyped field $(def)"), ctx, deep=false)
+            if !pragmaexists("Ignore untyped field $(def)", ctx, deep=false)
                 msg(ctx, :I691, def, "a type is not given to the field which can be slow")
             end
             push!(fields, (def, Any))

--- a/test/DEMOMODULE.jl
+++ b/test/DEMOMODULE.jl
@@ -14,7 +14,7 @@ end
 
 function lint_helper(ex::Expr, ctx::LintContext)
     if ex.head == :macrocall
-        if ex.args[1] == symbol("@fancyfuncgen")
+        if ex.args[1] == Symbol("@fancyfuncgen")
             if typeof(ex.args[2]) != Symbol
                 Lint.msg(ctx, 2, "@fancyfuncgen must use a symbol argument")
             else

--- a/test/array.jl
+++ b/test/array.jl
@@ -140,7 +140,7 @@ msgs = lintstr(s)
 @test contains(msgs[1].message, "typeof(x) == Any")
 
 s = """
-s = utf8("abcdef")
+s = "abcdef"
 s = s[chr2ind(s,2) :end]
 """
 msgs = lintstr(s)
@@ -148,7 +148,7 @@ msgs = lintstr(s)
 @test contains(msgs[1].message, "ambiguity of :end as a symbol vs as part of a range")
 
 s = """
-s = utf8("abcdef")
+s = "abcdef"
 sndlast = s[end -1]
 """
 msgs = lintstr(s)

--- a/test/doc.jl
+++ b/test/doc.jl
@@ -38,6 +38,7 @@ msgs = lintstr(s)
 
 s = """
 func(v) = v
+
 \"\"\"
 Documentation
 \"\"\"

--- a/test/funcall.jl
+++ b/test/funcall.jl
@@ -313,7 +313,7 @@ end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{Float64}}")
+@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{Float64")
 
 s = """
 function f(args::Float64...)

--- a/test/misuse.jl
+++ b/test/misuse.jl
@@ -41,7 +41,7 @@ msgs = lintstr(s)
 @test contains(msgs[1].message, "apparent non-Bool type")
 
 s = """
-d = Dict{int, int}()
+d = Dict{float, float}()
 """
 msgs = lintstr(s)
 

--- a/test/stagedfuncs.jl
+++ b/test/stagedfuncs.jl
@@ -34,6 +34,6 @@ end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{DataType}}")
+@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{DataType")
 @test msgs[2].code == :I271
 @test contains(msgs[2].message, "typeof(x) == DataType")

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -39,7 +39,7 @@ end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(b) == ASCIIString")
+@test contains(msgs[1].message, "typeof(b) == $(Compat.ASCIIString)")
 
 s = """
 function f()


### PR DESCRIPTION
This fixes tests and most deprecations on the latest master. Dict comprehension deprecation is not fixed; that might need to wait for Compat support? Or we can replace it with `Dict([...])`.