### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.8
+Compat 0.8.2

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,7 @@ lintpkg("MyPackage")
 
 If your package always lints clean, you may want to keep it that way in a test:
 ```julia
-@test isempty(lintpkg("MyPackage", returnMsgs=true))
+@test isempty(lintpkg("MyPackage"))
 ```
 
 

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -178,7 +178,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | **I5** | *Type Info*
 | I571   | the 1st statement under the true-branch is a boolean expression
 | I572   | assert x type= X but assign a value of Y
-| I581   | there is only 1 key type && 1 value type. Use explicit Dict{K,V}() for better performances
+| I581   | (removed in Lint 0.3.0)
 |        |
 | **I6** | *Structure Info*
 | I671   | new is provided with fewer arguments than fields

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -106,7 +106,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | E534   | introducing a new name for an implicit argument to the function, use {T<:X}
 | E535   | introducing a new name for an algebric data type, use {T<:X}
 | E536   | use {T<:...} instead of a known type
-| E537   | non-existent constructor, use string() for string conversion
+| E537   | String constructor does not exist in v0.4; use string() instead
 | E538   | known type in parametric data type, use {T<:...}
 |        |
 | **E6** | *Structure Error*

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -1,9 +1,11 @@
 # LintMessage
 
-When you lint some code Lint.jl will print the error messages in the [format described below](#format). By default nothing will be returned. If you want the messages to be returned then you have to set the `returnMsgs` keyword argument to `true` which will make Lint.jl return and array of `LintMessage`.
+When you lint some code, Lint.jl will print the error messages in the [format
+described below](#format). Lint will return a `LintResult` which behaves like an
+iterable of `LintMessage`s.
 
 ```julia
-lintpkg("MyPackage", returnMsgs=true)
+lintpkg("MyPackage")
 ```
 
 ## Format
@@ -21,7 +23,7 @@ filename.jl:Line CODE variable: message
 
 There are 3 levels of severity a LintMessage can be:
 
-* **Error:** The most sever level. Will probably lead to program failure.
+* **Error:** The most severe level. Will probably lead to program failure.
 * **Warning:** Code that will run but is probably wrong.
 * **Info:** Suggestions and best practices.
 
@@ -29,7 +31,7 @@ You can use `iserror`, `iswarning` and `isinfo` to check a particular messages e
 
 If you only want to test for error and warning level messages you could use:
 ```julia
-errors = filter(i -> !isinfo(i), lintpkg("MyPackage", returnMsgs=true))
+errors = filter(i -> !isinfo(i), lintpkg("MyPackage"))
 @test isempty(errors)
 ```
 

--- a/src/dict.jl
+++ b/src/dict.jl
@@ -55,12 +55,5 @@ function lintdict4(ex::Expr, ctx::LintContext)
         if length(vtypes) > 1 && ex.args[1].args[3] != :Any && !isexpr(ex.args[1].args[3], :call)
             msg(ctx, :E532, "multiple value types detected. Use Dict{K,Any}() for mixed type dict")
         end
-    else
-        # if the expression is explicitly (Any=>Any)[:a => 1], then it'd be
-        #   :Any=>:Any, not GlobalRef(Base, :Any)=> GlobalRef(Base, :Any)
-        if !in(Any, ktypes) && length(ktypes) == 1 && !in(Any, vtypes) && length(vtypes) == 1
-            msg(ctx, :I581, "there is only 1 key type && 1 value type. Use explicit " *
-                "Dict{K,V}() for better performances")
-        end
     end
 end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -442,9 +442,9 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
                 msg(ctx, :I481, row[1], "in 0.4+, replace $(row[1])() with $(repl)()$(suffix)")
             end
         end
-        if ex.args[1] == :String
-            msg(ctx, :E537, ex.args[1], "non-existent constructor, use string() for " *
-                "string conversion")
+        if VERSION < v"0.5-" && ex.args[1] == :String
+            msg(ctx, :E537, ex.args[1],
+                "String constructor does not exist in v0.4; use string() instead")
         elseif ex.args[1] == :Union
             msg(ctx, :E421, "use Union{...}, with curly, instead of parentheses")
         elseif ex.args[1] == :(+)

--- a/src/messages.jl
+++ b/src/messages.jl
@@ -74,10 +74,3 @@ function clean_messages!(msgs::Array{LintMessage})
     end
     deleteat!(msgs, delids)
 end
-
-function display_messages(msgs::Array{LintMessage})
-    colors = Dict{Symbol, Symbol}(:INFO => :bold, :WARN => :yellow, :ERROR => :magenta)
-    for m in msgs
-        Base.println_with_color(colors[level(m)], string(m))
-    end
-end

--- a/src/result.jl
+++ b/src/result.jl
@@ -1,0 +1,37 @@
+const LINT_RESULT_COLORS = Dict(
+    :INFO => :bold,
+    :WARN => :yellow,
+    :ERROR => :magenta,
+    :OK => :green)
+
+"""
+A collection of `LintMessage`s. This behaves similarly to a vector of
+`LintMessage`s, but has different display behaviour.
+"""
+immutable LintResult <: AbstractVector{LintMessage}
+    messages::Array{LintMessage, 1}
+end
+
+function Base.show(io::IO, res::LintResult)
+    print(io, "LintResult(")
+    show(io, res.messages)
+    print(io, ")")
+end
+@compat function Base.show(io::IO, ::MIME"text/plain", res::LintResult)
+    for m in res.messages
+        Base.println_with_color(LINT_RESULT_COLORS[level(m)], io, string(m))
+    end
+end
+
+Base.length(r::LintResult) = length(r.messages)
+Base.size(r::LintResult) = size(r.messages)
+Base.isempty(r::LintResult) = isempty(r.messages)
+Base.start(r::LintResult) = start(r.messages)
+Base.done(r::LintResult, s) = done(r.messages, s)
+Base.next(r::LintResult, s) = next(r.messages, s)
+
+# delegate getindex to parent collection
+Base.getindex(r::LintResult, i...) = r.messages[i...]
+
+# this function is useful for filtering on severity level
+Base.filter(p, r::LintResult) = LintResult(filter(p, r.messages))

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -5,6 +5,5 @@ p = "non_existing_1234_4321"
 @test_throws(AbstractString, lintpkg(p))
 
 # Lint package with full path
-msgs = lintpkg(joinpath(Pkg.dir("Lint"), "test", "FakePackage"); returnMsgs = true)
-Lint.display_messages(msgs)
+msgs = lintpkg(joinpath(Pkg.dir("Lint"), "test", "FakePackage"))
 @test isempty(msgs)

--- a/test/dictkey.jl
+++ b/test/dictkey.jl
@@ -4,17 +4,6 @@ s = """
 msgs = lintstr(s)
 @test msgs[1].code == :E334
 @test contains(msgs[1].message, "duplicate key in Dict")
-@test msgs[2].code == :I581
-@test contains(msgs[2].message, "there is only 1 key type && 1 value type. Use explicit " *
-    "Dict{K,V}() for better performances")
-
-s = """
-@compat Dict(:a=>Date(2014, 1, 1), :b=>Date(2015, 1, 1))
-"""
-msgs = lintstr(s)
-@test msgs[1].code == :I581
-@test contains(msgs[1].message, "there is only 1 key type && 1 value type. Use explicit " *
-    "Dict{K,V}() for better performances")
 
 s = """
 @compat Dict{Symbol,Int}(:a=>1, :b=>"")

--- a/test/globals.jl
+++ b/test/globals.jl
@@ -83,11 +83,11 @@ msgs = lintstr(s)
 
 # Test gloabls defined in other files
 # File in package src
-msgs = lintfile("FakePackage/src/subfolder2/file2.jl"; returnMsgs = true)
+msgs = lintfile("FakePackage/src/subfolder2/file2.jl")
 @test isempty(msgs)
 # File in package test
-msgs = lintfile("FakePackage/test/file2.jl"; returnMsgs = true)
+msgs = lintfile("FakePackage/test/file2.jl")
 @test isempty(msgs)
 # File in base julia
-msgs = lintfile("FakeJulia/base/file2.jl"; returnMsgs = true)
+msgs = lintfile("FakeJulia/base/file2.jl")
 @test isempty(msgs)

--- a/test/import.jl
+++ b/test/import.jl
@@ -24,3 +24,4 @@ script = \"test.jl\"; include(script)
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I372
+@test isempty(filter(x -> !isinfo(x), msgs))

--- a/test/linthelper.jl
+++ b/test/linthelper.jl
@@ -2,9 +2,9 @@
 include("DEMOMODULE.jl") # this provide the macro that generates functions
 include("DEMOMODULE2.jl") # this uses the first module's macro. It would export the generated functions
 
-msgs = lintfile("DEMOMODULE2.jl"; returnMsgs = true)
+msgs = lintfile("DEMOMODULE2.jl")
 @test isempty(msgs)
 
-msgs = lintfile("DEMOMODULE3.jl"; returnMsgs = true)
+msgs = lintfile("DEMOMODULE3.jl")
 @test msgs[1].code == :E311
 @test contains(msgs[1].message, "cannot find include file")

--- a/test/lintself.jl
+++ b/test/lintself.jl
@@ -1,4 +1,7 @@
 println("Linting Lint itself")
-msgs = lintpkg("Lint"; returnMsgs = true)
+msgs = lintpkg("Lint")
 # println(msgs)
 @test isempty(msgs)
+@test length(msgs) === 0
+@test size(msgs) === (0,)
+@test_throws BoundsError msgs[1]

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -14,13 +14,15 @@ msgs = lintstr(s)
 @test msgs[1].code == :E422
 @test contains(msgs[1].message, "string uses * to concatenate")
 
-s = """
-s = String(1)
-"""
-msgs = lintstr(s)
-@test msgs[1].code == :E537
-@test contains(msgs[1].message, "non-existent constructor, use string() for string " *
-    "conversion")
+if VERSION < v"0.5-"
+    s = """
+    s = String(1)
+    """
+    msgs = lintstr(s)
+    @test msgs[1].code == :E537
+    @test contains(msgs[1].message,
+        "String constructor does not exist in v0.4; use string() instead")
+end
 
 s = """
 b = string(12)


### PR DESCRIPTION
First commit should be relatively uncontroversial. `String` means something different on 0.5, so this error should be turned off.

Second commit removes message I581, which was never correct. `Dict(:a => 1, :b => 2)` is already a `Dict{Symbol, Int}` and adding in the type annotations is not necessary for better performance.

Third commit replaces `returnMsgs` keyword argument with a `LintResult` type that is always returned, but displays well in multi-line. It retains all the `AbstractVector{LintMessage}` functionality by extending it. While I think this is a good idea, it would be good to get other opinions. (This also fixes #136.)