### PR TITLE
Avoid loading modules protected behind `if`

### DIFF
--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -112,9 +112,11 @@ type LintContext
     messages     :: Array{LintMessage, 1}
     versionreachable:: Function # VERSION -> true means this code is reachable by VERSION
     ignore       :: Array{LintIgnore, 1}
+    ifdepth      :: Int
     LintContext() = new("none", 0, 1, "", false, ".", AbstractString[],
-            Dict{Symbol,Any}(), Dict{Symbol,Any}(), Dict{Symbol,Any}(), 0, 0, 0, 0,
-            Any[LintStack(true)], LintMessage[], _ -> true, deepcopy(LINT_IGNORE_DEFAULT))
+            Dict{Symbol,Any}(), Dict{Symbol,Any}(), Dict{Symbol,Any}(), 0, 0, 0,
+            0, Any[LintStack(true)], LintMessage[], _ -> true,
+            deepcopy(LINT_IGNORE_DEFAULT), 0)
 end
 
 function LintContext(file::AbstractString; ignore::Array{LintIgnore, 1} = LintIgnore[])

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -24,6 +24,9 @@ function lintmodule(ex::Expr, ctx::LintContext)
 end
 
 function lintusing(ex::Expr, ctx::LintContext)
+    # Don't use modules protected by a guard (these can cause crashes!)
+    # see issue #149
+    ctx.ifdepth > 0 && return
     if ctx.functionLvl > 0
         msg(ctx, :E414, "using is not allowed inside function definitions")
     end

--- a/test/ifstmt.jl
+++ b/test/ifstmt.jl
@@ -163,3 +163,12 @@ true || 1==1 || 1==1
 """
 msgs = lintstr(s)
 @test isempty(msgs)
+
+# issue #149: it's not always safe to include modules
+s = """
+if 1 == 0  # suppress if false warning
+    using FakeModule149
+end
+"""
+msgs = lintstr(s)
+@test isempty(msgs)


### PR DESCRIPTION
Sometimes package authors put module loads behind `if` statements, because these module loads might only succeed under particular configurations. We should avoid loading modules protected behind `if` statements, even if it means possible false positives on undefined symbols. It is not sufficient to `try`-`catch` the load, because certain modules call native code and can terminate the entire process if we try to load them. An example is `Dtree.jl`.

Min repro of case this fixes:

```julia
Pkg.add("Dtree")
lintstr("if false; using Dtree; end")
``` 

Fix #149.