### PR TITLE
Add a precompile hint for `lintstr`

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -291,11 +291,7 @@ function lintexpr(ex::Expr, ctx::LintContext)
         msg(ctx, :E112, ex.args[1])
     else
         for sube in ex.args
-            if typeof(sube)== Expr
-                lintexpr(sube, ctx)
-            elseif typeof(sube)==Symbol
-                registersymboluse(sube, ctx)
-            end
+            lintexpr(sube, ctx)
         end
     end
 end

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -156,23 +156,19 @@ function lintstr{T<:AbstractString}(str::T, ctx::LintContext = LintContext(), li
     ctx.messages
 end
 
-function lintexpr(ex::Any, ctx::LintContext)
-    if typeof(ex) == Symbol
-        registersymboluse(ex, ctx)
-        return
-    end
+function lintexpr(ex::Symbol, ctx::LintContext)
+    registersymboluse(ex, ctx)
+end
 
-    if typeof(ex) == QuoteNode && typeof(ex.value) == Expr
+function lintexpr(ex::QuoteNode, ctx::LintContext)
+    if typeof(ex.value) == Expr
         ctx.quoteLvl += 1
         lintexpr(ex.value, ctx)
         ctx.quoteLvl -= 1
-        return
     end
+end
 
-    if typeof(ex) != Expr
-        return
-    end
-
+function lintexpr(ex::Expr, ctx::LintContext)
     for h in values(ctx.callstack[end].linthelpers)
         if h(ex, ctx) == true
             return
@@ -303,6 +299,10 @@ function lintexpr(ex::Any, ctx::LintContext)
         end
     end
 end
+
+# no-op fallback for other kinds of expressions (e.g. LineNumberNode) that we
+# don’t care to handle
+lintexpr(::Any, ::LintContext) = return
 
 """
 Include a file to your lintContext.

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -382,4 +382,7 @@ function lintserver(port)
     end
 end
 
+# precompile hints
+include("precompile.jl")
+
 end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,15 @@
+# Precompile linting some strings for performance
+
+lintstr("""
+x, y = 1, 2
+for i in 1:10
+    println(i)
+end
+if x == 0
+    let z = 1
+        println(x + z - y)
+    end
+elseif x == 1 && y == 2
+    println("precompile")
+end
+""")


### PR DESCRIPTION
Helps #156 (I think there's more we can do for that though.)

On my machine, this shaves about 25% off the time for initial `lintstr` compilation.