### PR TITLE
Remove dead code (v0.3-only)

### DIFF
--- a/docs/messages.md
+++ b/docs/messages.md
@@ -168,13 +168,13 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | I473   | value at position #i is the referenced y. OK if it represents permutations
 | I474   | iteration generates tuples, n of m variables used
 | I475   | bit-wise in a boolean context. (&, |) do not have short-circuit behavior
-| I481   | in 0.4+, replace x() with y()
+| I481   | replace x() with y()
 | I482   | used in a local scope. Improve readability by using 'local' or another name
-| I483   | {} may be deprecated. Use Any[]
-| I484   | untyped dictionary {a=>b for (a,b) in c}, may be deprecated. Use (Any=>Any)[a=>b for (a,b) in c]
-| I485   | untyped dictionary {a for a in c}, may be deprecated. Use (Any)[a for a in c]
-| I486   | dictionary [a=>b,...], may be deprecated. Use @compat Dict(a=>b,...)
-| I487   | (K=>V)[a=>b,...] may be deprecated. Use @compat Dict{K,V}(a=>b,...)
+| I483   | (removed in Lint 0.3.0)
+| I484   | (removed in Lint 0.3.0)
+| I485   | (removed in Lint 0.3.0)
+| I486   | (removed in Lint 0.3.0)
+| I487   | (removed in Lint 0.3.0)
 |        |
 | **I5** | *Type Info*
 | I571   | the 1st statement under the true-branch is a boolean expression

--- a/src/dict.jl
+++ b/src/dict.jl
@@ -1,17 +1,7 @@
-function lintdict(ex::Expr, ctx::LintContext; typed::Bool = false)
-    @lintpragma("Ignore unused ex")
-
-    if !typed
-        if VERSION < v"0.4-" && ctx.versionreachable(VERSION)
-            msg(ctx, :I486, "dictionary [a=>b,...], may be deprecated by Julia 0.4. " *
-                "Use @compat Dict(a=>b,...)")
-        end
-    else
-        if VERSION < v"0.4-" && ctx.versionreachable(VERSION)
-            msg(ctx, :I487, "(K=>V)[a=>b,...] may be deprecated by Julia 0.4. Use " *
-                "@compat Dict{K,V}(a=>b,...)")
-        end
-    end
+function lintdict(::Expr, ::LintContext; typed::Bool = false)
+    @lintpragma "Ignore unused typed"
+    # TODO: Complain about v0.4-style [a => b for x in y] Dict comprehensions,
+    # deprecated in v0.5.
 end
 
 function lintdict4(ex::Expr, ctx::LintContext)

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -418,18 +418,14 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
         ]
         versionreachable = ctx.versionreachable(VERSION)
         for row in deprector
-            if VERSION < v"0.4.0-dev+1830" && versionreachable && ex.args[1] == row[2]
-                msg(ctx, :E432, row[2], "though valid in 0.4, use $(row[1])() instead of " *
-                    "$(row[2])()")
-            end
-            if VERSION >= v"0.4.0-dev+1830" && versionreachable && ex.args[1] == row[1]
+            if versionreachable && ex.args[1] == row[1]
                 repl = string(row[2])
                 suffix = ""
                 if contains(repl, "Int")
                     suffix = ", or some of the other explicit conversion functions. " *
                         "(round, trunc, etc...)"
                 end
-                msg(ctx, :I481, row[1], "in 0.4+, replace $(row[1])() with $(repl)()$(suffix)")
+                msg(ctx, :I481, row[1], "replace $(row[1])() with $(repl)()$(suffix)")
             end
         end
         if VERSION < v"0.5-" && ex.args[1] == :String

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -55,9 +55,6 @@ function linttyped_hcat(ex::Expr, ctx::LintContext)
 end
 
 function lintcell1d(ex::Expr, ctx::LintContext)
-    if VERSION < v"0.4-"
-        msg(ctx, :I483, "{} may be deprecated in Julia 0.4. Use Any[]")
-    end
     for a in ex.args
         lintexpr(a, ctx)
     end


### PR DESCRIPTION
This code was protected by a less than version 0.4 guard, and since Lint doesn't support 0.3 any more, it's no longer useful. Unfortunately, this doesn't seem to have a visible effect on #156 (since it turns out there isn't much dead code).