### PR TITLE
Simplify `registersymboluse`

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -39,6 +39,7 @@ include("curly.jl")
 include("misc.jl")
 include("init.jl")
 include("result.jl")
+include("dynamic.jl")
 
 function lintpkg{T<:AbstractString}(pkg::T; returnMsgs=nothing)
     # FIXME: deprecated summer 2016, remove after reasonable amount of time

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,0 +1,18 @@
+"""
+Determine the type of suspected imported binding `sym`. Return `:DataType` if
+it is a likely type, `:var` if it likely exists but is likely not a type, and
+`:Any` if it cannot be located, which may indicate.
+"""
+function dynamic_imported_binding_type(sym)
+    if isdefined(Main, sym)
+        if isupper(string(sym)[1])
+            try
+                if isa(eval(Main, sym), Type)
+                    return :DataType
+                end
+            end
+        end
+        return :var
+    end
+    :Any
+end

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -70,29 +70,19 @@ function registersymboluse(sym::Symbol, ctx::LintContext, strict::Bool=true)
         return :var
     end
 
-    found = false
-    ret = :var
+    # Move up call stack, looking at global declarations
     for i in length(ctx.callstack):-1:1
         if in(sym, ctx.callstack[i].types)
-            found = true
-            ret = :DataType
+            return :DataType
         elseif haskey(ctx.callstack[i].declglobs, sym) ||
-            in(sym, ctx.callstack[i].functions) ||
-            in(sym, ctx.callstack[i].modules) ||
-            in(sym, ctx.callstack[i].imports)
-            found = true
-        end
-
-        if found
-            # looking up variables we found global
-            # note: found global variables are not the same as declared globals
-            if i != length(ctx.callstack) &&
-                haskey(ctx.callstack[i].declglobs, sym)
-            end
-            return ret
+               in(sym, ctx.callstack[i].functions) ||
+               in(sym, ctx.callstack[i].modules) ||
+               in(sym, ctx.callstack[i].imports)
+            return :var
         end
     end
 
+    # Fall back to dynamic evaluation in Main
     result = dynamic_imported_binding_type(sym)
 
     if strict && result === :Any &&

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -62,28 +62,11 @@ function registersymboluse(sym::Symbol, ctx::LintContext, strict::Bool=true)
         end
     end
 
-    str = string(sym)
-    if isupper(str[1])
-        @lintpragma("Ignore incompatible type comparison")
-        t = nothing
-        try
-            tmp = eval(Main, sym)
-            t = typeof(tmp)
-        catch
-            t = nothing
-        end
-        if t == DataType
-            return :DataType
-        elseif t != nothing
-            return :var
-        end
-    end
-
     # a bunch of whitelist to just grandfather-in
-    if in(sym, knowntypes)
+    if sym in knowntypes
         return :DataType
     end
-    if in(sym, knownsyms)
+    if sym in knownsyms
         return :var
     end
 
@@ -101,51 +84,26 @@ function registersymboluse(sym::Symbol, ctx::LintContext, strict::Bool=true)
         end
 
         if found
-            # if in looking up variables we found global, from then
-            # on we treat the variable as if we have had declared "global"
-            # within the scope block
+            # looking up variables we found global
+            # note: found global variables are not the same as declared globals
             if i != length(ctx.callstack) &&
                 haskey(ctx.callstack[i].declglobs, sym)
-                register_global(
-                    ctx,
-                    sym,
-                    ctx.callstack[i].declglobs[sym]
-               )
             end
             return ret
         end
     end
 
-    maybefunc = nothing
-    t = nothing
-    try
-        maybefunc = eval(Main, sym)
-        t = typeof(maybefunc)
-    catch
-        t = nothing
-    end
-    if t == Function
-        register_global(
-            ctx,
-            sym,
-            @compat(Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line))
-       )
-        return :var
-    end
+    result = dynamic_imported_binding_type(sym)
 
-    if !strict
-        return :Any
+    if strict && result === :Any &&
+       !pragmaexists("Ignore use of undeclared variable $sym", ctx)
+        if ctx.quoteLvl == 0
+            msg(ctx, :E321, sym, "use of undeclared symbol")
+        elseif ctx.isstaged
+            msg(ctx, :I371, sym, "use of undeclared symbol")
+        end
     end
-
-    if pragmaexists("Ignore use of undeclared variable $sym", ctx)
-        return :Any
-    end
-    if ctx.quoteLvl == 0
-        msg(ctx, :E321, sym, "use of undeclared symbol")
-    elseif ctx.isstaged
-        msg(ctx, :I371, sym, "use of undeclared symbol")
-    end
-    return :Any
+    return result
 end
 
 function lintglobal(ex::Expr, ctx::LintContext)


### PR DESCRIPTION
Avoid using dynamic techniques, which are slow and error-prone, unless absolutely necessary. Remove unnecessary global reregistration, as used globals are not declared globals. Remove spurious temporary variables.

My performance benchmarking suggests a 10% improvement in time to lint Lint itself. This is a first step toward #152.