### PR TITLE
Remove Julia 0.3 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Build Status](https://travis-ci.org/tonyhffong/Lint.jl.svg?branch=master)](https://travis-ci.org/tonyhffong/Lint.jl)
 [![Coverage Status](https://img.shields.io/coveralls/tonyhffong/Lint.jl.svg)](https://coveralls.io/r/tonyhffong/Lint.jl)  
-[![Lint](http://pkg.julialang.org/badges/Lint_0.3.svg)](http://pkg.julialang.org/?pkg=Lint&ver=0.3)
 [![Lint](http://pkg.julialang.org/badges/Lint_0.4.svg)](http://pkg.julialang.org/?pkg=Lint&ver=0.4)
 [![Lint](http://pkg.julialang.org/badges/Lint_0.5.svg)](http://pkg.julialang.org/?pkg=Lint&ver=0.5)
 


### PR DESCRIPTION
Julia 0.3 has not been supported by this package for a long time,
and http://pkg.julialang.org/ no longer lists it.