### PR TITLE
Get Lint working on 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.4
-Compat 0.8.2
+Compat 0.11.0

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -23,6 +23,8 @@ import Base: ==
 include("exprutils.jl")
 using .ExpressionUtils
 
+include("statictype.jl")
+
 include("linttypes.jl")
 include("messages.jl")
 include("knownsyms.jl")

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -20,6 +20,9 @@ end
 
 import Base: ==
 
+include("exprutils.jl")
+using .ExpressionUtils
+
 include("linttypes.jl")
 include("messages.jl")
 include("knownsyms.jl")

--- a/src/curly.jl
+++ b/src/curly.jl
@@ -6,13 +6,13 @@
 # contracts for common collections / type parametrized types
 # TODO: Can we be more specific here? What about detecting contract?
 const CURLY_CONTRACTS = Dict{Symbol, Any}(
-    :Array  => (DataType, Integer),
-    :Dict   => (DataType, DataType),
-    :Matrix => (DataType,),
-    :Set    => (DataType,),
-    :Type   => (DataType,),
+    :Array  => (Type, Integer),
+    :Dict   => (Type, Type),
+    :Matrix => (Type,),
+    :Set    => (Type,),
+    :Type   => (Type,),
     :Val    => (Any,),
-    :Vector => (DataType,))
+    :Vector => (Type,))
 
 function lintcurly(ex::Expr, ctx::LintContext)
     head = ex.args[1]
@@ -28,7 +28,7 @@ function lintcurly(ex::Expr, ctx::LintContext)
             continue # grandfathered
         else
             t = guesstype(a, ctx)
-            if !(t == DataType || t == Symbol || isbits(t) || t == Any)
+            if !(t <: Type || t == Symbol || isbits(t) || t == Any)
                 msg(ctx, :W441, a, "probably illegal use inside curly")
             elseif contract != nothing
                 if i - 1 > length(contract)

--- a/src/dynamic.jl
+++ b/src/dynamic.jl
@@ -1,14 +1,14 @@
 """
-Determine the type of suspected imported binding `sym`. Return `:DataType` if
-it is a likely type, `:var` if it likely exists but is likely not a type, and
-`:Any` if it cannot be located, which may indicate.
+Determine the type of suspected imported binding `sym`. Return `:Type` if it is
+a likely type, `:var` if it likely exists but is likely not a type, and `:Any`
+if it cannot be located, which may indicate.
 """
 function dynamic_imported_binding_type(sym)
     if isdefined(Main, sym)
         if isupper(string(sym)[1])
             try
                 if isa(eval(Main, sym), Type)
-                    return :DataType
+                    return :Type
                 end
             end
         end

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -1,0 +1,47 @@
+module ExpressionUtils
+
+using Base.Meta
+
+export split_comparison, simplify_literal
+
+"""
+    split_comparison(::Expr)
+
+Split a :comparison expression into an equivalent :&& expression, given that
+each component of the comparison is pure.
+"""
+function split_comparison(ex)
+    if !isexpr(ex, :comparison)
+        throw(ArgumentError("expected a comparison expression, got a $(ex.head)"))
+    end
+    left = ex.args[1]
+    op = ex.args[2]
+    right = ex.args[3]
+    remainder = ex.args[3:end]
+    if length(remainder) == 1
+        :($op($left, $right))
+    else
+        :($op($left, $right) &&
+          $(split_comparison(Expr(:comparison, remainder...))))
+    end
+end
+
+"""
+    simplify_literal(::Expr)
+
+Simplify certain macros into the literals they produce.
+
+Simplifications performed include:
+
+ - v"x.y.z" literals are simplified into `VersionNumber` objects.
+"""
+function simplify_literal(ex)
+    if isexpr(ex, :macrocall) && ex.args[1] == Symbol("@v_str") &&
+       isa(ex.args[2], AbstractString)
+        VersionNumber(ex.args[2])
+    else
+        ex
+    end
+end
+
+end

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -293,7 +293,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
     if ctorType != Symbol("") && fname == ctorType
         t = guesstype(ex.args[2], ctx)
         if isa(t, Type)
-            if t.name.name != ctorType
+            if t ≠ Any && t.name.name != ctorType
                 msg(ctx, :E611, "constructor doesn't seem to return the constructed object")
             end
         elseif t != ctorType

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -55,7 +55,7 @@ function initcommoncollfuncs()
 end
 
 function lintfuncargtype(ex, ctx::LintContext)
-    if typeof(ex) <: Expr && ex.head == :curly
+    if isexpr(ex, :curly)
         st = 2
         en = 1
         if ex.args[1] == :Array
@@ -75,7 +75,7 @@ end
 # a constructor for a type. We would check
 # * if the function name matches the type name
 function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstaged=false)
-    if length(ex.args) == 1 && typeof(ex.args[1]) == Symbol
+    if length(ex.args) == 1 && isa(ex.args[1], Symbol)
         # generic function without methods
         return
     end
@@ -97,7 +97,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
     elseif isexpr(ex.args[1].args[1], :(.))
         fname = ex.args[1].args[1]
         push!(ctx.callstack[end].functions, fname.args[end])
-    elseif typeof(ex.args[1].args[1]) == Symbol
+    elseif isa(ex.args[1].args[1], Symbol)
         fname = ex.args[1].args[1]
         push!(ctx.callstack[end].functions, fname)
     elseif !isa(ex.args[1].args[1], Expr)
@@ -108,7 +108,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
         push!(ctx.callstack[end].functions, fname)
         for i in 2:length(ex.args[1].args[1].args)
             adt = ex.args[1].args[1].args[i]
-            if typeof(adt) == Symbol
+            if isa(adt, Symbol)
                 if in(adt, knowntypes)
                     msg(ctx, :E534, adt, "introducing a new name for an implicit " *
                         "argument to the function, use {T<:$(adt)}")
@@ -161,7 +161,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
     assertions = Dict{Symbol, Any}() # e.g. x::Int
 
     resolveArguments = (sube, position) -> begin # zero position means it's not called at the top level
-        if typeof(sube) == Symbol
+        if isa(sube, Symbol)
             if in(sube, argsSeen)
                 msg(ctx, :E331, sube, "duplicate argument")
             end
@@ -176,13 +176,13 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
             return sube
         elseif sube.head == :parameters
             for (j,kw) in enumerate(sube.args)
-                if typeof(kw)==Expr && kw.head == :(...)
+                if isexpr(kw, :(...))
                     if j != length(sube.args)
                         msg(ctx, :E412, kw, "named ellipsis ... can only be the last argument")
                         return
                     end
                     sym = resolveArguments(kw, 0)
-                    if typeof(sym)== Symbol
+                    if isa(sym, Symbol)
                         if isstaged
                             assertions[sym] = Type
                         else
@@ -191,7 +191,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
                         end
                     end
                     return
-                elseif typeof(kw) != Expr || (kw.head != :(=) && kw.head != :kw)
+                elseif !isexpr(kw, [:(=), :kw])
                     msg(ctx, :E423, kw, "named keyword argument must have a default")
                     return
                 else
@@ -206,7 +206,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
             sym = resolveArguments(sube.args[1], 0)
             if !isstaged
                 rhstype = guesstype(sube.args[2], ctx)
-                if typeof(sym) == Symbol
+                if isa(sym, Symbol)
                     typeRHShints[sym] = rhstype
                 end
             end
@@ -214,7 +214,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
             if length(sube.args) > 1
                 sym = resolveArguments(sube.args[1], 0)
                 if !isstaged
-                    if typeof(sym) == Symbol
+                    if isa(sym, Symbol)
                         dt = Any
                         try
                             dt = parsetype(sube.args[2])
@@ -234,7 +234,7 @@ function lintfunction(ex::Expr, ctx::LintContext; ctorType = Symbol(""), isstage
                 msg(ctx, :E413, sube, "positional ellipsis ... can only be the last argument")
             end
             sym = resolveArguments(sube.args[1], 0)
-            if typeof(sym) == Symbol
+            if isa(sym, Symbol)
                 if isstaged
                     assertions[sym] = Tuple{Vararg{Type}}
                 elseif haskey(assertions, sym)
@@ -343,7 +343,7 @@ function lintlambda(ex::Expr, ctx::LintContext)
     end
 
     resolveArguments = (sube) -> begin
-        if typeof(sube) == Symbol
+        if isa(sube, Symbol)
             checklambdaarg(sube)
             stacktop.localarguments[end][sube] = VarInfo(ctx.line)
         #= # until lambda supports named args, keep this commented
@@ -367,7 +367,7 @@ function lintlambda(ex::Expr, ctx::LintContext)
         end
     end
 
-    if typeof(ex.args[1]) == Symbol
+    if isa(ex.args[1], Symbol)
         resolveArguments(ex.args[1])
     elseif isexpr(ex.args[1], :tuple)
         for i = 1:length(ex.args[1].args)
@@ -385,7 +385,7 @@ end
 
 function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
     if ex.args[1] == :include
-        if typeof(ex.args[2]) <: AbstractString
+        if isa(ex.args[2], AbstractString)
             inclfile = string(ex.args[2])
         else
             inclfile = ""
@@ -441,7 +441,7 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
 
         skiplist = Int[]
 
-        if typeof(ex.args[1]) == Symbol && haskey(commoncollmethods, ex.args[1])
+        if isa(ex.args[1], Symbol) && haskey(commoncollmethods, ex.args[1])
             known=true
             s = ex.args[1]
             typesig = Any[]
@@ -462,8 +462,8 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
         #splice! allows empty range such as 3:2, it means inserting an array
         # between position 2 and 3, without taking out any value.
         if ex.args[1] == Symbol("splice!") && Meta.isexpr(ex.args[3], :(:)) &&
-            length(ex.args[3].args) == 2 && typeof(ex.args[3].args[1]) <: Real &&
-            typeof(ex.args[3].args[2]) <: Real && ex.args[3].args[2] < ex.args[3].args[1]
+            length(ex.args[3].args) == 2 && isa(ex.args[3].args[1], Real) &&
+            isa(ex.args[3].args[2], Real) && ex.args[3].args[2] < ex.args[3].args[1]
             push!(skiplist, 3)
         end
 
@@ -486,7 +486,7 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
         end
 
         st = 2
-        if ex.args[1] == :ifelse && typeof(ex.args[2]) == Expr
+        if ex.args[1] == :ifelse
             lintboolean(ex.args[2], ctx)
             st = 3
             known = true
@@ -500,7 +500,7 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
 
         if isexpr(ex.args[1], :(.))
             lintexpr(ex.args[1], ctx)
-        elseif typeof(ex.args[1]) == Symbol
+        elseif isa(ex.args[1], Symbol)
             push!(ctx.callstack[end].calledfuncs, ex.args[1])
         end
 
@@ -514,7 +514,7 @@ function lintfunctioncall(ex::Expr, ctx::LintContext; inthrow::Bool=false)
             end
         end
 
-        if !inthrow && typeof(ex.args[1]) == Symbol
+        if !inthrow && isa(ex.args[1], Symbol)
             s = lowercase(string(ex.args[1]))
             if contains(s,"error") || contains(s,"exception") || contains(s,"mismatch") || contains(s,"fault")
                 try

--- a/src/guesstype.jl
+++ b/src/guesstype.jl
@@ -10,27 +10,19 @@ valuetype{K,V}(::Type{Associative{K,V}}) = V
 keytype{T<:Associative}(::Type{T}) = keytype(supertype(T))
 valuetype{T<:Associative}(::Type{T}) = valuetype(supertype(T))
 
-function isAnyOrTupleAny(x)
-    if x == Any
-        return true
-    elseif typeof(x) <: Tuple
-        return all(y->y == Any, x)
-    end
-    return false
-end
-
-function evaltype(ex)
+function evaltype(ex::Symbol)
     ret = Any
     try
-        ret = eval(Main, ex)
+        ret = getfield(Base, ex)
     end
     return isa(ret, Type) ? ret : Any
 end
+evaltype(ex) = Any
 
 # ex should be a type. figure out what it is
 function parsetype(ex)
     ret = Any
-    if typeof(ex) <: Symbol
+    if isa(ex, Symbol)
         return evaltype(ex)
     elseif typeof(ex) <: Expr
         if isexpr(ex, :curly)
@@ -288,7 +280,7 @@ function guesstype(ex, ctx::LintContext)
         end
 
         elt = evaltype(ex.args[2])
-        if length(sig) >= 1 && sig[1] == Type
+        if length(sig) >= 1 && sig[1] <: Type
             if length(sig) == 2 && isexpr(ex.args[3], :tuple)
                 return Array{elt, length(ex.args[3].args)}
             elseif length(sig) == 2 && sig[2] <: Tuple && all(x->x <: Integer, sig[2])

--- a/src/knownsyms.jl
+++ b/src/knownsyms.jl
@@ -20,14 +20,14 @@ function cacheknownsyms()
     union!(knowntypes, filter(names(Base)) do x
         ok = false
         try
-            ok = isa(eval(Base, x), DataType)
+            ok = isa(eval(Base, x), Type)
         end
         ok
     end)
     union!(knowntypes, filter(names(Core)) do x
         ok = false
         try
-            ok = isa(eval(Core, x), DataType)
+            ok = isa(eval(Core, x), Type)
         end
         ok
     end)

--- a/src/linttypes.jl
+++ b/src/linttypes.jl
@@ -9,11 +9,11 @@ end
 
 type VarInfo
     line::Int
-    typeactual::Any # most of the time it's DataType, but could be Tuple of types, too
+    typeactual::Type
     typeexpr::Union{Expr, Symbol} # We may know that it is Array{T, 1}, though we do not know T, for example
     VarInfo() = new(-1, Any, :())
     VarInfo(l::Int) = new(l, Any, :())
-    VarInfo(l::Int, t::DataType) = new(l, t, :())
+    VarInfo(l::Int, t::Type) = new(l, t, :())
     VarInfo(l::Int, ex::Expr) = new(l, Any, ex)
     VarInfo(ex::Expr) = new(-1, Any, ex)
 end

--- a/src/pragma.jl
+++ b/src/pragma.jl
@@ -1,5 +1,5 @@
 function lintlintpragma(ex::Expr, ctx::LintContext)
-    if length(ex.args) >= 2 && typeof(ex.args[2]) <: AbstractString
+    if length(ex.args) >= 2 && isa(ex.args[2], AbstractString)
         m = match(r"^((Print)|(Info)|(Warn)|(Error)) ((type)|(me)|(version)) +(.+)"s, ex.args[2])
         if m != nothing
             action = m.captures[1]
@@ -11,7 +11,7 @@ function lintlintpragma(ex::Expr, ctx::LintContext)
                     msg(ctx, :E138, rest_str, "incomplete pragma expression")
                     str = ""
                 else
-                    str = "typeof(" * rest_str * ") == " * string(guesstype(v, ctx))
+                    str = "typeof($rest_str) == $(guesstype(v, ctx))"
                 end
             elseif infotype == "me"
                 str = rest_str

--- a/src/ref.jl
+++ b/src/ref.jl
@@ -3,11 +3,11 @@ function lintref(ex::Expr, ctx::LintContext)
     guesstype(ex, ctx) # tickle the type checks on the expression
     if typeof(sub1)== Symbol
         # check to see if it's a type
-        what = registersymboluse(sub1, ctx, false) # :var, :DataType, or :Any
+        what = registersymboluse(sub1, ctx, false) # :var, :Type, or :Any
         if what == :Any
             str = string(sub1)
             #if !isupper(str[1]) || length(str) <= 2
-            msg(ctx, :W544, str, "Lint cannot determine if DataType or not")
+            msg(ctx, :W544, str, "Lint cannot determine if Type or not")
             #end
         end
     else

--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -1,0 +1,20 @@
+module StaticTypeAnalysis
+
+"""
+    StaticTypeAnalysis.length(T::Type)
+
+If it can be determined that all objects of type `T` have length `n`, then
+return `Nullable(n)`. Otherwise, return `Nullable{Int}()`.
+"""
+length(::Type{Union{}}) = Nullable(0)
+length(::Type) = Nullable{Int}()
+length{T<:Pair}(::Type{T}) = 2
+if VERSION < v"0.6-"
+    length{T<:Tuple}(::Type{T}) = Nullable{Int}(Base.length(T.parameters))
+else
+    include_string("""
+    length(::Type{T}) where T <: NTuple{N, Any} where N = Nullable{Int}(N)
+    """)
+end
+
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -46,7 +46,7 @@ function linttype(ex::Expr, ctx::LintContext)
                 end
                 if in(typeconstraint, knowntypes)
                     dt = eval(typeconstraint)
-                    if typeof(dt) == DataType && isleaftype(dt)
+                    if isa(dt, Type) && isleaftype(dt)
                         msg(ctx, :E513, adt, "leaf type as a type constraint makes no sense")
                     end
                 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -88,44 +88,42 @@ msgs = lintstr(s)
 @test msgs[2].code == :I271
 @test contains(msgs[2].message, "typeof(x2) == Array{Int64,2}")
 @test msgs[3].code == :I271
-@test contains(msgs[3].message, "typeof(x3) == Array{T,N}")
+@test contains(msgs[3].message, "typeof(x3) == $Array")
 @test msgs[4].code == :I271
 @test contains(msgs[4].message, "typeof(x4) == Array{Float64,2}")
 
 # more array function
 s = """
 function f(t::Array{Int64,2}, m, n)
-    x1 = slicedim(t, 2, 1)
     x2 = reshape(t, 1)
     x3 = reshape(t, (1,2))
     x4 = reshape(m, (1,2))
     x5 = reshape(t, n)
     x6 = reshape(t, 1, 2)
     x7 = t'
-    @lintpragma("Info type x1")
+    x8 = (1, 2)
     @lintpragma("Info type x2")
     @lintpragma("Info type x3")
     @lintpragma("Info type x4")
     @lintpragma("Info type x5")
     @lintpragma("Info type x6")
     @lintpragma("Info type x7")
+    @lintpragma("Info type x8")
 end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(x1) == Array{Int64,2}")
+@test contains(msgs[1].message, "typeof(x2) == Array{Int64,1}")
 @test msgs[2].code == :I271
-@test contains(msgs[2].message, "typeof(x2) == Array{Int64,1}")
+@test contains(msgs[2].message, "typeof(x3) == Array{Int64,2}")
 @test msgs[3].code == :I271
-@test contains(msgs[3].message, "typeof(x3) == Array{Int64,2}")
+@test contains(msgs[3].message, "typeof(x4) == Any")
 @test msgs[4].code == :I271
-@test contains(msgs[4].message, "typeof(x4) == Any")
+@test contains(msgs[4].message, "typeof(x5) == Array{Int64,N}")
 @test msgs[5].code == :I271
-@test contains(msgs[5].message, "typeof(x5) == Array{Int64,N}")
+@test contains(msgs[5].message, "typeof(x6) == Array{Int64,2}")
 @test msgs[6].code == :I271
-@test contains(msgs[6].message, "typeof(x6) == Array{Int64,2}")
-@test msgs[7].code == :I271
-@test contains(msgs[7].message, "typeof(x7) == Array{Int64,2}")
+@test contains(msgs[6].message, "typeof(x7) == Array{Int64,2}")
 
 s = """
 function f(a::Array{Float64})

--- a/test/funcall.jl
+++ b/test/funcall.jl
@@ -223,11 +223,11 @@ msgs = lintstr(s)
 @test msgs[1].code == :I271
 @test contains(msgs[1].message, "typeof(a) == Array{Any,1}")
 @test msgs[2].code == :I271
-@test contains(msgs[2].message, "typeof(n) == Int")
+@test contains(msgs[2].message, "typeof(n) == Tuple{Int64}")
 @test msgs[3].code == :I271
 @test contains(msgs[3].message, "typeof(tmp) == Array{Any,1}")
 @test msgs[4].code == :I271
-@test contains(msgs[4].message, "typeof(T) == DataType")
+@test contains(msgs[4].message, "typeof(T) == Type")
 @test msgs[5].code == :I271
 @test contains(msgs[5].message, "typeof(tmp2) == Array{Any,1}")
 @test msgs[6].code == :I271

--- a/test/misuse.jl
+++ b/test/misuse.jl
@@ -50,7 +50,7 @@ if VERSION < v"0.5.0-dev+2959"
 @test msgs[2].code == :W441
 else
 @test msgs[1].code == :W447
-@test contains(msgs[1].message, "it should be of type DataType")
+@test contains(msgs[1].message, "it should be of type Type")
 @test msgs[2].code == :W447
-@test contains(msgs[2].message, "it should be of type DataType")
+@test contains(msgs[2].message, "it should be of type Type")
 end

--- a/test/server.jl
+++ b/test/server.jl
@@ -12,7 +12,7 @@ write(conn, "empty\n")
 write(conn, "1\n")
 write(conn, "\n")
 
-@test readline(conn) == "\n"
+@test chomp(readline(conn)) == ""
 
 
 conn = connect(port)
@@ -21,7 +21,7 @@ write(conn, "4\n")
 write(conn, "bad\n")
 
 @test contains(readline(conn), "use of undeclared symbol")
-@test readline(conn) == "\n"
+@test chomp(readline(conn)) == ""
 
 # This isn't working on the nightly build. Ideally we explicitly stop the server process (as
 # it loops forever). It seems to get stopped when the tests end, so it's not necessary.

--- a/test/stagedfuncs.jl
+++ b/test/stagedfuncs.jl
@@ -34,6 +34,6 @@ end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{DataType")
+@test contains(msgs[1].message, "typeof(args) == Tuple{Vararg{Type")
 @test msgs[2].code == :I271
-@test contains(msgs[2].message, "typeof(x) == DataType")
+@test contains(msgs[2].message, "typeof(x) == ")

--- a/test/typecheck.jl
+++ b/test/typecheck.jl
@@ -148,7 +148,7 @@ end
 msgs = lintstr(s)
 @test msgs[1].code == :E521
 @test msgs[1].variable == "a"
-@test contains(msgs[1].message, "apparent type DataType is not a container type")
+@test contains(msgs[1].message, "apparent type Type")
 
 s = """
 function f()


### PR DESCRIPTION
The first commit converts DataType to Type everywhere. This should always have been the case, but is especially important in 0.6, as many types like `Array` are now `UnionAll`s instead of `DataType`s.

The second commit rewrites the version constraint code to not call `eval`. Not calling `eval` is a good idea anyway, but is especially important in 0.6 due to the world age restrictions. The calling of new methods created with `eval` is subject to world age restrictions in 0.6, and removing the `eval` addresses that issue.

The third commit changes from `typeof(x) == T` to `isa(x, T)` in many places. 0.6 introduces new `x isa T` syntax which would make sense to use in the future, and this is a first step toward that modernization.

The fourth commit addresses the remaining, miscellaneous problems that prevent Lint from working properly on 0.6, and involves some updates to legacy code (this fixes several issues along the way). Overall, Lint should be better at detecting types. Once 0.4 support is dropped, large amounts of code can be removed.

The fifth commit (in progress) fixes breakage of 0.4 and 0.5 introduced by the first four commits.

Fixes #79 
Fixes #137 