### PR TITLE
Fixing src/Lint.jl lintserver conn to close properly and testing it in test/server.jl

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -74,10 +74,10 @@ Lint message suppression (do not include the square brackets)
 * `@lintpragma("Ignore unused [variable name]")`. Works for unused arguments also.
 * `@lintpragma("Ignore unstable type variable [variable name]")`. Ignore type instability warnings.
 * `@lintpragma("Ignore deprecated [function name]")`
-* `@lintpragma("Ignore undefined module [module name]")`. Useful to support Julia packages across 
+* `@lintpragma("Ignore undefined module [module name]")`. Useful to support Julia packages across
     different Julia releases.
 * `@lintpragma("Ignore untyped field [field name]")`.
-* `@lintpragma("Ignore dimensionless array field [field name]")`. Useful if we really want to store 
+* `@lintpragma("Ignore dimensionless array field [field name]")`. Useful if we really want to store
     arrays with uncertain/runtime-calculated dimension
 * `@lintpragma("Ignore use of undeclared variable [variable name]")`. Useful when using macros to
   generate symbols on the fly.
@@ -210,6 +210,7 @@ This feature is useful when you want to lint julia code in a non julia environme
 
 Existing plugins:
  * Sublime Text: [SublimeLinter-contrib-julialintserver](https://github.com/invenia/SublimeLinter-contrib-julialintserver)
+ * linter-julia for Atom: [linter-julia](https://github.com/TeroFrondelius/linter-julia)
 
 The protocol for the server is:
 
@@ -240,12 +241,12 @@ println(socket, str) # code
 
 response = ""
 line = ""
-while line != "\n"
+while isopen(socket)
     response *= line
     line = readline(socket)
 end
 
-@assert response == "none:1 E422 : string uses * to concatenate\n"
+@assert response == "none:1 E422 : string uses * to concatenate\n\n"
 ```
 
 Note that the first request might take some time because the linting functions are being imported and compiled.

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -1,4 +1,4 @@
-__precompile__(true)
+  __precompile__(true)
 
 module Lint
 
@@ -330,7 +330,7 @@ function lintinclude(ctx::LintContext, file::AbstractString)
 end
 
 """
-Lint all \*.jl files at a given directory.
+Lint all *.jl files at a given directory.
 Will ignore LintContext file and already included files.
 """
 function lintdir{T<:AbstractString}(dir::T, ctx::LintContext=LintContext())
@@ -346,14 +346,14 @@ function lintdir{T<:AbstractString}(dir::T, ctx::LintContext=LintContext())
 end
 
 function readandwritethestream(conn)
-    println("Connection accepted")
+    # println("Connection accepted")
     # Get file, code length and code
     file = strip(readline(conn))
-    println("file: ", file)
+    # println("file: ", file)
     code_len = parse(Int, strip(readline(conn)))
-    println("Code bytes: ", code_len)
+    # println("Code bytes: ", code_len)
     code = Compat.UTF8String(read(conn, code_len))
-    println("Code received")
+    # println("Code received")
     # Do the linting
     msgs = lintfile(file, code)
     # Write response to socket
@@ -363,8 +363,6 @@ function readandwritethestream(conn)
     end
     # Blank line to indicate end of messages
     write(conn, "\n")
-    println("Connection closed")
-    close(conn)
 end
 
 function lintserver(port)
@@ -374,13 +372,17 @@ function lintserver(port)
         while true
             conn = accept(server)
             @async try
-              readandwritethestream(conn)
+                readandwritethestream(conn)
             catch err
-              println("connection ended with error $err")
+                println(STDERR, "connection ended with error $err")
+            finally
+                close(conn)
+                # println("Connection closed")
             end
         end
     finally
         close(server)
+        println("Server closed")
     end
 end
 

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -1,4 +1,4 @@
-  __precompile__(true)
+__precompile__(true)
 
 module Lint
 

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -330,7 +330,7 @@ function lintinclude(ctx::LintContext, file::AbstractString)
 end
 
 """
-Lint all *.jl files at a given directory.
+Lint all \*.jl files at a given directory.
 Will ignore LintContext file and already included files.
 """
 function lintdir{T<:AbstractString}(dir::T, ctx::LintContext=LintContext())
@@ -345,6 +345,28 @@ function lintdir{T<:AbstractString}(dir::T, ctx::LintContext=LintContext())
     ctx.messages
 end
 
+function readandwritethestream(conn)
+    println("Connection accepted")
+    # Get file, code length and code
+    file = strip(readline(conn))
+    println("file: ", file)
+    code_len = parse(Int, strip(readline(conn)))
+    println("Code bytes: ", code_len)
+    code = Compat.UTF8String(read(conn, code_len))
+    println("Code received")
+    # Do the linting
+    msgs = lintfile(file, code)
+    # Write response to socket
+    for i in msgs
+        write(conn, string(i))
+        write(conn, "\n")
+    end
+    # Blank line to indicate end of messages
+    write(conn, "\n")
+    println("Connection closed")
+    close(conn)
+end
+
 function lintserver(port)
     server = listen(port)
     try
@@ -352,24 +374,7 @@ function lintserver(port)
         while true
             conn = accept(server)
             @async try
-                println("Connection accepted")
-                # Get file, code length and code
-                file = strip(readline(conn))
-                println("file: ", file)
-                code_len = parse(Int, strip(readline(conn)))
-                println("Code bytes: ", code_len)
-                code = Compat.UTF8String(read(conn, code_len))
-                println("Code received")
-                # Do the linting
-                msgs = lintfile(file, code)
-                # Write response to socket
-                for i in msgs
-                    write(conn, string(i))
-                    write(conn, "\n")
-                end
-                # Blank line to indicate end of messages
-                write(conn, "\n")
-                println("Connection closed")
+              readandwritethestream(conn)
             catch err
               println("connection ended with error $err")
             end

--- a/test/server.jl
+++ b/test/server.jl
@@ -7,20 +7,20 @@ server = @async lintserver(port)
 sleep(1) #let server start
 
 @testset "lintserver() tests" begin
-  conn = connect(port)
-  write(conn, "empty\n")
-  write(conn, "1\n")
-  write(conn, "\n")
+    conn = connect(port)
+    write(conn, "empty\n")
+    write(conn, "1\n")
+    write(conn, "\n")
 
-  @test chomp(readline(conn)) == ""
+    @test chomp(readline(conn)) == ""
 
-  conn = connect(port)
-  write(conn, "undeclared_symbol\n")
-  write(conn, "4\n")
-  write(conn, "bad\n")
+    conn = connect(port)
+    write(conn, "undeclared_symbol\n")
+    write(conn, "4\n")
+    write(conn, "bad\n")
 
-  @test contains(readline(conn), "use of undeclared symbol")
-  @test chomp(readline(conn)) == ""
+    @test contains(readline(conn), "use of undeclared symbol")
+    @test chomp(readline(conn)) == ""
 end
 
 @testset "Testing the lintserver addition" begin

--- a/test/server.jl
+++ b/test/server.jl
@@ -6,23 +6,23 @@ port = conn[1]
 server = @async lintserver(port)
 sleep(1) #let server start
 
+@testset "lintserver() tests" begin
+  conn = connect(port)
+  write(conn, "empty\n")
+  write(conn, "1\n")
+  write(conn, "\n")
 
-conn = connect(port)
-write(conn, "empty\n")
-write(conn, "1\n")
-write(conn, "\n")
-
-@test readline(conn) == "\n"
+  @test readline(conn) == "\n"
 
 
-conn = connect(port)
-write(conn, "undeclared_symbol\n")
-write(conn, "4\n")
-write(conn, "bad\n")
+  conn = connect(port)
+  write(conn, "undeclared_symbol\n")
+  write(conn, "4\n")
+  write(conn, "bad\n")
 
-@test contains(readline(conn), "use of undeclared symbol")
-@test readline(conn) == "\n"
-
+  @test contains(readline(conn), "use of undeclared symbol")
+  @test readline(conn) == "\n"
+end
 
 @testset "Testing the lintserver addition" begin
     function lintbyserver(socket)


### PR DESCRIPTION
Thanks for the good work. I wrote [an Atom package linter-julia](https://github.com/TeroFrondelius/linter-julia), which uses the lintserver(). However, node.js client thinks lintserver isn't closing properly and thus stay busy. Eventually the fix could have been just the close(conn), but I wanted to keep a backward compatibility thus making this `readandwritethestream()` function of the old `@async try` internals solved the trick by itself. At least those two tests, which I added now works with julia 0.5.0.    
