### PR TITLE
Drop v0.4 testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:


### PR DESCRIPTION
All this does is stop testing Travis on v0.4. There is no code change for now. Future PRs can now use 0.5 features without worrying about 0.4 compatibility, and I anticipate that some of the outdated 0.4 code will be removed as we go along.