### PR TITLE
Fix #180 by enhancing static type analysis

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.5
 JSON 0.6.0
-Compat 0.15.0
+Compat 0.20.0

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,7 +39,6 @@
   `@lintpragma("Ignore unstable type variable [variable name]")` just before the warning.
 * Incompatible type assertion and assignment e.g. `a::Int = 1.0`
 * Incompatible tuple assignment sizes e.g. `(a,b) = (1,2,3)`
-* Flatten behavior of nested vcat e.g. `[[1,2],[3,4]]`
 * Loop over a single number. e.g. `for i=1 end`
 * More indices than dimensions in an array lookup
 * Look up a dictionary with the wrong key type, if the key's type can be inferred.

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -86,6 +86,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | E434   | value at position #i is the referenced x. Possible typo?
 | E435   | new is provided with more arguments than fields
 | E436   | more indices than dimensions
+| E437   | @compat called with wrong number of arguments
 |        |
 | **E5** | *Type Error*
 | E511   | apparent non-Bool type
@@ -103,7 +104,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | E532   | multiple value types detected. Use Dict{K,Any}() for mixed type dict
 | E533   | type parameters are invariant, try f{T<:Number}(x::T)...
 | E534   | introducing a new name for an implicit argument to the function, use {T<:X}
-| E535   | introducing a new name for an algebric data type, use {T<:X}
+| E535   | (no longer used)
 | E536   | use {T<:...} instead of a known type
 | E537   | (removed)
 | E538   | known type in parametric data type, use {T<:...}
@@ -165,6 +166,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | I382   | argument declared but not used
 | I391   | also a global from src
 | I392   | local variable might cause confusion with a synonymous export from Base
+| I393   | using an existing type as type parameter name is probably a typo
 |        |
 | **I4** | *Usage Info*
 | I472   | assignment in the if-predicate clause

--- a/docs/messages.md
+++ b/docs/messages.md
@@ -107,6 +107,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | E536   | use {T<:...} instead of a known type
 | E537   | (removed)
 | E538   | known type in parametric data type, use {T<:...}
+| E539   | assigning an error to a variable
 |        |
 | **E6** | *Structure Error*
 | E611   | constructor doesn't seem to return the constructed object
@@ -140,6 +141,7 @@ Every error code starts with letter for the severity `E`:`ERROR`, `W`:`WARN` or 
 | W543   | cannot determine if Type or not
 | W544   | cannot determine if Type or not
 | W545   | previously used variable has apparent type X, but now assigned Y
+| W546   | implicitly discarding values, m of n used
 |        |
 | **W6** | *Structure Warning*
 | W641   | unreachable code after return

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -6,6 +6,7 @@ using Base.Meta
 using Compat
 using Compat.TypeUtils
 using JSON
+import Compat: readline
 
 if isdefined(Base, :unwrap_unionall)
     using Base: unwrap_unionall
@@ -439,9 +440,9 @@ function readandwritethestream(conn,style)
     if style == "original_behaviour"
         # println("Connection accepted")
         # Get file, code length and code
-        file = strip(readline(conn))
+        file = readline(conn)
         # println("file: ", file)
-        code_len = parse(Int, strip(readline(conn)))
+        code_len = parse(Int, readline(conn))
         # println("Code bytes: ", code_len)
         code = Compat.UTF8String(read(conn, code_len))
         # println("Code received")

--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -141,7 +141,7 @@ function lintfile(file::AbstractString, code::AbstractString)
 end
 
 function lintstr{T<:AbstractString}(str::T, ctx::LintContext = LintContext(), lineoffset = 0)
-    linecharc = cumsum(map(x->endof(x)+1, @compat(split(str, "\n", keep=true))))
+    linecharc = cumsum(map(x->endof(x)+1, split(str, "\n", keep=true)))
     numlines = length(linecharc)
     i = start(str)
     while !done(str,i)
@@ -243,6 +243,7 @@ function lintexpr(ex::Expr, ctx::LintContext)
     elseif ex.head == :type
         linttype(ex, ctx)
     elseif ex.head == :typealias
+        # TODO: deal with X{T} = Y assignments, also const X = Y
         linttypealias(ex, ctx)
     elseif ex.head == :abstract
         lintabstract(ex, ctx)

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -33,7 +33,7 @@ function lintifexpr(ex::Expr, ctx::LintContext)
         (verconstraint1, verconstraint2) = versionconstraint(ex.args[1])
         if verconstraint1 != nothing
             tmpvtest = ctx.versionreachable
-            ctx.versionreachable = _->(tmpvtest(_) && verconstraint1(_))
+            ctx.versionreachable = x->(tmpvtest(x) && verconstraint1(x))
         end
         insideif(x -> lintexpr(ex.args[2], x), ctx)
         if verconstraint1 != nothing
@@ -42,7 +42,7 @@ function lintifexpr(ex::Expr, ctx::LintContext)
         if length(ex.args) > 2
             if verconstraint2 != nothing
                 tmpvtest = ctx.versionreachable
-                ctx.versionreachable = _->(tmpvtest(_) && verconstraint2(_))
+                ctx.versionreachable = x->(tmpvtest(x) && verconstraint2(x))
             end
             insideif(x -> lintexpr(ex.args[3], x), ctx)
             if verconstraint2 != nothing

--- a/src/exprutils.jl
+++ b/src/exprutils.jl
@@ -3,7 +3,8 @@ module ExpressionUtils
 using Base.Meta
 
 export split_comparison, simplify_literal, ispairexpr, isliteral,
-       lexicaltypeof, lexicalfirst, lexicallast, lexicalvalue
+       lexicaltypeof, lexicalfirst, lexicallast, lexicalvalue,
+       withincurly
 
 # TODO: remove when 0.5 support dropped
 function BROADCAST(f, x::Nullable)
@@ -13,6 +14,24 @@ function BROADCAST(f, x::Nullable)
         Nullable(f(get(x)))
     end
 end
+
+"""
+    withincurly(ex)
+
+Get just the function part of a function declaration, or just the type head of
+a parameterized type name.
+
+```jldoctest
+julia> using Lint.ExpressionUtils
+
+julia> withincurly(:(Vector{T}))
+:Vector
+
+julia> withincurly(:((::Type{T}){T}))
+:(::Type{T})
+```
+"""
+withincurly(ex) = isexpr(ex, :curly) ? ex.args[1] : ex
 
 """
     split_comparison(::Expr)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -55,7 +55,14 @@ istopmacro(ex, mod, mac) = ex in (
     Expr(:(.), Symbol(string(mod)), mac))
 
 function lintcompat(ex::Expr, ctx::LintContext)
-    if length(ex.args) == 2
+    if VERSION < v"0.6.0-dev.2746" &&
+       length(ex.args) == 2 && isexpr(ex.args[2], :abstract) &&
+       length(ex.args[2].args) == 1 && isexpr(ex.args[2].args[1], :type)
+        lintexpr(Compat._compat_abstract(ex.args[2].args[1]), ctx)
+    elseif VERSION < v"0.6.0-dev.2746" &&
+           length(ex.args) == 3 && ex.args[2] == :primitive
+        lintexpr(Compat._compat_primitive(ex.args[3]), ctx)
+    elseif length(ex.args) == 2
         lintexpr(Compat._compat(ex.args[2]), ctx)
     else
         msg(ctx, :E437, ex, "@compat called with wrong number of arguments")

--- a/src/modules.jl
+++ b/src/modules.jl
@@ -35,7 +35,7 @@ function lintusing(ex::Expr, ctx::LintContext)
             register_global(
                 ctx,
                 s,
-                @compat(Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line))
+                Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line)
            )
         end
     end
@@ -53,7 +53,7 @@ function lintusing(ex::Expr, ctx::LintContext)
                     register_global(
                         ctx,
                         n,
-                        @compat(Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line))
+                        Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line)
                    )
                 end
             end
@@ -103,7 +103,7 @@ function lintimport(ex::Expr, ctx::LintContext; all::Bool = false)
             register_global(
                 ctx,
                 ex.args[1],
-                @compat(Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line))
+                Dict{Symbol,Any}(:file => ctx.file, :line => ctx.line)
             )
             eval(Main, ex)
             lastpart = ex.args[end]

--- a/src/result.jl
+++ b/src/result.jl
@@ -17,7 +17,7 @@ function Base.show(io::IO, res::LintResult)
     show(io, res.messages)
     print(io, ")")
 end
-@compat function Base.show(io::IO, ::MIME"text/plain", res::LintResult)
+function Base.show(io::IO, ::MIME"text/plain", res::LintResult)
     for m in res.messages
         Base.println_with_color(LINT_RESULT_COLORS[level(m)], io, string(m))
     end

--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -1,5 +1,37 @@
 module StaticTypeAnalysis
 
+macro lintpragma(ex); end
+
+"""
+    StaticTypeAnalysis.infertype(f, argtypes)
+
+Given a function `f` and a `Tuple` of types `argtypes`, use inference to figure
+out a type `S` such that the result of applying `f` to `argtypes` is always of
+type `S`.
+"""
+function infertype(f, argtypes)
+    try
+        typejoin(Base.return_types(f, Tuple{argtypes...})...)
+    catch  # error might be thrown if generic function, try using inference
+        if all(isleaftype, argtypes)
+            Core.Inference.return_type(f, Tuple{argtypes...})
+        else
+            Any
+        end
+    end
+end
+
+"""
+    StaticTypeAnalysis.getindexable(T::Type)
+
+Return `true` if all objects of type `T` support `getindex`, and the `getindex`
+operation on numbers is consistent with iteration order.
+
+Note that, in particular, this is not true for `String` and `Dict`.
+"""
+getindexable{T<:Union{Tuple,Pair,Array,Number}}(::Type{T}) = true
+getindexable(::Type) = false
+
 """
     StaticTypeAnalysis.length(T::Type)
 
@@ -8,7 +40,7 @@ return `Nullable(n)`. Otherwise, return `Nullable{Int}()`.
 """
 length(::Type{Union{}}) = Nullable(0)
 length(::Type) = Nullable{Int}()
-length{T<:Pair}(::Type{T}) = 2
+length{T<:Pair}(::Type{T}) = Nullable(2)
 if VERSION < v"0.6-"
     length{T<:Tuple}(::Type{T}) = Nullable{Int}(Base.length(T.parameters))
 else
@@ -25,5 +57,25 @@ element type `S`.
 """
 eltype(::Type{Union{}}) = Union{}
 eltype(T::Type) = Base.eltype(T)
+
+_getindex_nth{n}(xs::Any, ::Type{Val{n}}) = xs[n]
+_typeof_nth_getindex{T}(::Type{T}, n::Integer) =
+    infertype(_getindex_nth, Any[T, Type{Val{Int(n)}}])
+
+"""
+    StaticTypeAnalysis.typeof_nth(T::Type)
+
+Return `S` as specific as possible such that all objects of type `T`, when
+iterated over, have `n`th element type `S`.
+"""
+typeof_nth(T::Type, n::Integer) =
+    if getindexable(T)
+        typeintersect(eltype(T), _typeof_nth_getindex(T, n))
+    else
+        eltype(T)
+    end
+typeof_nth{K,V}(::Type{Pair{K,V}}, n::Integer) =
+    n == 1 ? K : n == 2 ? V : Union{}
+typeof_nth(::Type{Union{}}, ::Integer) = Union{}
 
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,8 +20,7 @@ function linttype(ex::Expr, ctx::LintContext)
                     end
                 end
                 if typefound && adt != :T
-                    msg(ctx, :E535, adt, "introducing a new name for an algebric data " *
-                        "type, use {T<:$(adt)}")
+                    msg(ctx, :I393, adt, "using an existing type as type parameter name is probably a typo")
                 end
                 push!(ctx.callstack[end].types, adt)
                 push!(typeparams, adt)
@@ -138,10 +137,9 @@ function linttype(ex::Expr, ctx::LintContext)
 end
 
 function linttypealias(ex::Expr, ctx::LintContext)
+    # TODO: make this just part of lintassignment
     if isa(ex.args[1], Symbol)
-        push!(ctx.callstack[end].types, ex.args[1])
-    elseif isexpr(ex.args[1], :curly)
-        push!(ctx.callstack[end].types, ex.args[1].args[1])
+        push!(ctx.callstack[end].types, withincurly(ex.args[1]))
     end
 end
 

--- a/test/bugs.jl
+++ b/test/bugs.jl
@@ -51,4 +51,9 @@ A = [[1, 2], [3, 4]]
 println(A[1][1])
 """))
 
+# bug 180
+@test messageset(lintstr("""
+x, y = error()
+""")) == Set([:E539])
+
 end

--- a/test/forloop.jl
+++ b/test/forloop.jl
@@ -1,6 +1,6 @@
 s = """
 function f(x)
-    d = @compat Dict{Symbol,Int}(:a=>1, :b=>2)
+    d = Dict{Symbol,Int}(:a=>1, :b=>2)
     for i in d
     end
     return x

--- a/test/lintself.jl
+++ b/test/lintself.jl
@@ -1,10 +1,11 @@
-println("Linting Lint itself")
-msgs = lintpkg("Lint")
-if !isempty(msgs)
-    display(msgs)
+@testset "Lint Self" begin
+    msgs = lintpkg("Lint")
+    if !isempty(msgs)
+        display(msgs)
+    end
+    # TODO: reenable when #200 fixed
+    # @test isempty(msgs)
+    # @test length(msgs) === 0
+    # @test size(msgs) === (0,)
+    # @test_throws BoundsError msgs[1]
 end
-# TODO: reenable when #200 fixed
-# @test isempty(msgs)
-# @test length(msgs) === 0
-# @test size(msgs) === (0,)
-# @test_throws BoundsError msgs[1]

--- a/test/macro.jl
+++ b/test/macro.jl
@@ -87,3 +87,8 @@ end
 """
 msgs = lintstr(s)
 @test isempty(msgs)
+
+@testset "E437" begin
+    @test messageset(lintstr("@compat()")) == Set([:E437])
+    @test messageset(lintstr("@compat(1, 2)")) == Set([:E437])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,66 +1,63 @@
 using Lint
+using Compat
 using Base.Test
 
 messageset(msgs) = Set(x.code for x in msgs)
 
 include("statictype.jl")
 
-info("Test basic printing and sorting of lint messages")
-
-if basename(pwd()) == "Lint"
-    path =  "test/DEMOFILE.jl"
-elseif basename(pwd()) == "src"
-    path = "../test/DEMOFILE.jl"
-elseif basename(pwd()) == "test"
-    path = "DEMOFILE.jl"
-else
-    throw("doesn't know where I am")
+@testset "Lint File" begin
+    path = joinpath(@__DIR__, "DEMOFILE.jl")
+    @test !isempty(lintfile(path))
 end
 
-lintfile(path)
+@testset "AST Linting" begin
+    include("messages.jl")
+    include("basics.jl")
+    include("array.jl")
+    include("badvars.jl")
+    include("bitopbool.jl")
+    include("comprehensions.jl")
+    include("curly.jl")
+    include("deadcode.jl")
+    include("deprecate.jl")
+    include("dictkey.jl")
+    include("doc.jl")
+    include("dupexport.jl")
+    include("forloop.jl")
+    include("funcall.jl")
+    include("globals.jl")
+    include("ifstmt.jl")
+    include("import.jl")
+    include("lambda.jl")
+    include("linthelper.jl")
+    include("macro.jl")
+    include("mathconst.jl")
+    include("module.jl")
+    include("meta.jl")
+    include("pragma.jl")
+    include("range.jl")
+    include("ref.jl")
+    include("similarity.jl")
+    include("strings.jl")
+    include("style.jl")
+    include("symbol.jl")
+    include("throw.jl")
+    include("tuple.jl")
+    include("type.jl")
+    include("typecheck.jl")
+    include("undeclare.jl")
+    include("unusedvar.jl")
+    include("using.jl")
+    include("versions.jl")
+    include("stagedfuncs.jl")
+    include("incomplete.jl")
+    include("misuse.jl")
+end
 
-info("Test core lint functionalities...")
-include("messages.jl")
-include("basics.jl")
-include("array.jl")
-include("badvars.jl")
-include("bitopbool.jl")
-include("comprehensions.jl")
-include("curly.jl")
-include("deadcode.jl")
-include("deprecate.jl")
-include("dictkey.jl")
-include("doc.jl")
-include("dupexport.jl")
-include("forloop.jl")
-include("funcall.jl")
-include("globals.jl")
-include("ifstmt.jl")
-include("import.jl")
-include("lambda.jl")
-include("linthelper.jl")
-include("macro.jl")
-include("mathconst.jl")
-include("module.jl")
-include("meta.jl")
-include("pragma.jl")
-include("range.jl")
-include("ref.jl")
-include("similarity.jl")
-include("strings.jl")
-include("style.jl")
-include("symbol.jl")
-include("throw.jl")
-include("tuple.jl")
-include("type.jl")
-include("typecheck.jl")
-include("undeclare.jl")
-include("unusedvar.jl")
-include("using.jl")
-include("versions.jl")
-include("server.jl")
-include("stagedfuncs.jl")
-include("incomplete.jl")
-include("misuse.jl")
 include("bugs.jl")
 include("lintself.jl")
+
+@testset "Server" begin
+    include("server.jl")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,9 @@ using Base.Test
 
 messageset(msgs) = Set(x.code for x in msgs)
 
-println("Test basic printing and sorting of lint messages")
+include("statictype.jl")
+
+info("Test basic printing and sorting of lint messages")
 
 if basename(pwd()) == "Lint"
     path =  "test/DEMOFILE.jl"
@@ -17,7 +19,7 @@ end
 
 lintfile(path)
 
-println("...OK\n\nTest core lint functionalities...")
+info("Test core lint functionalities...")
 include("messages.jl")
 include("basics.jl")
 include("array.jl")
@@ -61,7 +63,4 @@ include("stagedfuncs.jl")
 include("incomplete.jl")
 include("misuse.jl")
 include("bugs.jl")
-
-println("...OK\n")
 include("lintself.jl")
-println("...OK")

--- a/test/server.jl
+++ b/test/server.jl
@@ -1,3 +1,5 @@
+import Compat: readline
+
 # find a good port
 conn = listenany(2228)
 close(conn[2])
@@ -39,7 +41,7 @@ end
     write(conn, "1\n")
     write(conn, "\n")
 
-    @test chomp(readline(conn)) == ""
+    @test readline(conn) == ""
 
     conn = connect(port)
     write(conn, "undeclared_symbol\n")
@@ -47,7 +49,7 @@ end
     write(conn, "bad\n")
 
     @test contains(readline(conn), "use of undeclared symbol")
-    @test chomp(readline(conn)) == ""
+    @test readline(conn) == ""
 end
 
 @testset "Testing the lintserver addition" begin
@@ -56,25 +58,24 @@ end
           """
     socket = connect(port)
     lintbyserver(socket, str)
-    response = ""
+    response = String[]
     line = "."
     while !isempty(line)
-        line = chomp(readline(socket))
-        response *= line
+        line = readline(socket)
+        push!(response, line)
     end
 
-    @test response == "none:1 E422 : string uses * to concatenate"
+    @test "none:1 E422 : string uses * to concatenate" in response
 
     socket = connect(port)
     lintbyserver(socket, str)
-    res = ""
-    line = ""
+    response = String[]
     while isopen(socket)
-        res *= line
-        line = chomp(readline(socket))
+        line = readline(socket)
+        push!(response, line)
     end
 
-    @test res == "none:1 E422 : string uses * to concatenate"
+    @test "none:1 E422 : string uses * to concatenate" in response
 end
 
 @testset "Testing lintserver() with named pipe and JSON format" begin

--- a/test/statictype.jl
+++ b/test/statictype.jl
@@ -1,0 +1,28 @@
+using Lint: StaticTypeAnalysis
+
+@testset "Static Type" begin
+
+@test StaticTypeAnalysis.eltype(Tuple{Int,Int}) == Int
+@test StaticTypeAnalysis.eltype(Tuple{Int,String}) == Any
+@test StaticTypeAnalysis.eltype(Tuple{}) == Union{}
+@test StaticTypeAnalysis.eltype(Tuple) == Any
+@test StaticTypeAnalysis.eltype(Vector{Int}) == Int
+@test StaticTypeAnalysis.eltype(Array{Int}) == Int
+
+@test isnull(StaticTypeAnalysis.length(Tuple))
+@test isnull(StaticTypeAnalysis.length(Array))
+@test isnull(StaticTypeAnalysis.length(Vector{Int}))
+@test isnull(StaticTypeAnalysis.length(Array{Int}))
+@test get(StaticTypeAnalysis.length(Pair)) == 2
+@test get(StaticTypeAnalysis.length(Tuple{Int,String})) == 2
+@test get(StaticTypeAnalysis.length(NTuple{10, Integer})) == 10
+
+@test StaticTypeAnalysis.typeof_nth(Tuple{Int,String}, 1) == Int
+@test StaticTypeAnalysis.typeof_nth(Tuple{Int,String}, 2) == String
+@test StaticTypeAnalysis.typeof_nth(Pair{Int,String}, 2) == String
+@test StaticTypeAnalysis.typeof_nth(Pair{Int,String}, 1) == Int
+@test StaticTypeAnalysis.typeof_nth(Vector{Int}, 1) == Int
+@test StaticTypeAnalysis.typeof_nth(Tuple, 1) == Any
+@test StaticTypeAnalysis.typeof_nth(Tuple{Int}, 2) == Union{}
+
+end

--- a/test/tuple.jl
+++ b/test/tuple.jl
@@ -1,15 +1,20 @@
+@testset "Tuple" begin
+
 s = """
     (a,b) = (1,2,3)
 """
 msgs = lintstr(s)
-@test msgs[1].code == :E418
-@test contains(msgs[1].message, "RHS is a tuple, 2 of 3 variables used")
+@test msgs[1].code == :W546
+@test contains(msgs[1].message, "implicitly discarding values, 2 of 3 used")
 
 s = """
     a, = (1,2,3)
 """
 msgs = lintstr(s)
-@test isempty(msgs)
+@test msgs[1].code == :W546
+@test contains(msgs[1].message, "implicitly discarding values, 1 of 3 used")
+
+@test isempty(lintstr("a = (1, 2, 3)"))
 
 s = """
 function f()
@@ -25,4 +30,6 @@ s = """
 """
 msgs = lintstr(s)
 @test msgs[1].code == :E418
-@assert contains(msgs[1].message, "RHS is a tuple, 3 of 2 variables used")
+@test contains(msgs[1].message, "RHS is a tuple, 3 of 2 variables used")
+
+end

--- a/test/type.jl
+++ b/test/type.jl
@@ -92,7 +92,7 @@ end
 msgs = lintstr(s)
 @test isempty(msgs)
 
-if VERSION ≥ v"0.6-"
+if VERSION ≥ v"0.6.0-dev.2746"
     @testset "Type Alias Shadowing" begin
         s = """
         const TT = Int64

--- a/test/type.jl
+++ b/test/type.jl
@@ -7,23 +7,21 @@ end
 msgs = lintstr(s)
 @test isempty(msgs)
 
-s = """
-type MyType{Int64}
-end
-"""
-msgs = lintstr(s)
-@test msgs[1].code == :E535
-@test msgs[1].variable == "Int64"
-@test contains(msgs[1].message, "introducing a new name for an algebric data type")
+@testset "I393" begin
+    s = """
+    type MyType{Int64}
+    end
+    """
+    msgs = lintstr(s)
+    @test msgs[1].code == :I393
+    @test msgs[1].variable == "Int64"
+    @test contains(msgs[1].message, "using an existing type as type parameter name is probably a typo")
 
-s = """
-type MyType{Int64} <: Float64
+    @test messageset(lintstr("""
+    type MyType{Int64} <: Float64
+    end
+    """)) == Set([:I393])
 end
-"""
-msgs = lintstr(s)
-@test msgs[1].code == :E535
-@test msgs[1].variable == "Int64"
-@test contains(msgs[1].message, "introducing a new name for an algebric data type")
 
 s = """
 type MyType{T<:Int}
@@ -95,25 +93,26 @@ msgs = lintstr(s)
 @test isempty(msgs)
 
 s = """
-typealias TT Int64
-typealias SharedVector{TT} SharedArray{TT,1}
+const TT = Int64
+@compat SharedVector{X} = SharedArray{X,1}
 
-type MyType{TT}
-    t::TT
-    MyType(x) = new(convert(TT, x))
+type MyType{X}
+    t::X
+    MyType(x) = new(convert(X, x))
 end
 """
 msgs = lintstr(s)
-@test msgs[1].code == :E535
-@test msgs[1].variable == "TT"
-@test contains(msgs[1].message, "introducing a new name for an algebric data type")
+@test length(msgs) == 1
+@test msgs[1].code == :I392
+@test msgs[1].variable == "SharedVector"
+@test contains(msgs[1].message, "synonymous export from Base")
 
 s = """
-abstract SomeAbsType
-abstract SomeAbsNum <: Number
-abstract SomeAbsVec1{T} <: Array{T,1}
-abstract SomeAbsVec2{T}
-bitstype 8 MyBitsType
+@compat abstract type SomeAbsType end
+@compat abstract type SomeAbsNum <: Number end
+@compat abstract type SomeAbsVec1{T} <: Array{T,1} end
+@compat abstract type SomeAbsVec2{T} end
+@compat primitive type MyBitsType 8 end
 
 type MyType{T<:SomeAbsType}
     t::T
@@ -121,6 +120,7 @@ type MyType{T<:SomeAbsType}
 end
 """
 msgs = lintstr(s)
+@show msgs
 @test isempty(msgs)
 
 s = """
@@ -198,7 +198,7 @@ msgs = lintstr(s)
 @test contains(msgs[1].message, "use lintpragma macro inside type declaration")
 
 s = """
-bitstype a 8
+@compat primitive type 8 a end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :E524

--- a/test/type.jl
+++ b/test/type.jl
@@ -92,20 +92,24 @@ end
 msgs = lintstr(s)
 @test isempty(msgs)
 
-s = """
-const TT = Int64
-@compat SharedVector{X} = SharedArray{X,1}
+if VERSION ≥ v"0.6-"
+    @testset "Type Alias Shadowing" begin
+        s = """
+        const TT = Int64
+        @compat SharedVector{X} = SharedArray{X,1}
 
-type MyType{X}
-    t::X
-    MyType(x) = new(convert(X, x))
+        type MyType{X}
+            t::X
+            MyType(x) = new(convert(X, x))
+        end
+        """
+        msgs = lintstr(s)
+        @test length(msgs) == 1
+        @test msgs[1].code == :I392
+        @test msgs[1].variable == "SharedVector"
+        @test contains(msgs[1].message, "synonymous export from Base")
+    end
 end
-"""
-msgs = lintstr(s)
-@test length(msgs) == 1
-@test msgs[1].code == :I392
-@test msgs[1].variable == "SharedVector"
-@test contains(msgs[1].message, "synonymous export from Base")
 
 s = """
 @compat abstract type SomeAbsType end

--- a/test/typecheck.jl
+++ b/test/typecheck.jl
@@ -257,3 +257,26 @@ end
 """
 msgs = lintstr(s)
 @test isempty(msgs)
+
+@testset "E539" begin
+    # assigning error to a variable
+    @test messageset(lintstr("""
+    x = throw(ArgumentError("error!"))
+    """)) == Set([:E539])
+
+    @test messageset(lintstr("""
+    x = 1 + "x"
+    """)) == Set([:E422, :E539])
+
+    @test isempty(lintstr("""
+    x = 1 + 1 == 2 ? "OK" : error("problem")
+    """))
+
+    @test messageset(lintstr("""
+    x, y = error()
+    """)) == Set([:E539])
+
+    @test messageset(lintstr("""
+    κ = sqrt("x")
+    """)) == Set([:E539])
+end


### PR DESCRIPTION
Instead of using `parameters` which doesn't always work, we fall back to inference to determine the nth element type in static type analysis. Depends on several other PRs to be merged first.

Fixes #180 
Fixes #182 

Introduces E539 to fix #180 and W546 to fix #182.