### PR TITLE
Don't call isvatuple on unions of tuples (fixes #215).

### DIFF
--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -121,7 +121,7 @@ length(::Type) = Nullable{Int}()
 length{T<:Pair}(::Type{T}) = Nullable(2)
 
 if VERSION < v"0.6.0-dev.2123" # where syntax introduced by julia PR #18457
-    length{T<:Tuple}(::Type{T}) = if !(T <: DataType) || Core.Inference.isvatuple(T)
+    length{T<:Tuple}(::Type{T}) = if !isa(T, DataType) || Core.Inference.isvatuple(T)
         Nullable{Int}()
     else
         Nullable{Int}(Base.length(T.types))

--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -121,7 +121,7 @@ length(::Type) = Nullable{Int}()
 length{T<:Pair}(::Type{T}) = Nullable(2)
 
 if VERSION < v"0.6.0-dev.2123" # where syntax introduced by julia PR #18457
-    length{T<:Tuple}(::Type{T}) = if Core.Inference.isvatuple(T)
+    length{T<:Tuple}(::Type{T}) = if !(T <: DataType) || Core.Inference.isvatuple(T)
         Nullable{Int}()
     else
         Nullable{Int}(Base.length(T.types))

--- a/test/bugs.jl
+++ b/test/bugs.jl
@@ -57,13 +57,21 @@ x, y = error()
 """)) == Set([:E539])
 
 # bug 166
-@test isempty(messageset(lintstr("""
+@test isempty(lintstr("""
 let x = :(type X end); x; end
-""")))
+"""))
 
 # bug 164
 @test messageset(lintstr("""
 undefined()
 """)) == Set([:E321])
+
+# bug 215
+@test isempty(lintstr("""
+x = (rand(Bool) ? (1,) : (1.0,),)
+for (i,) in x
+    @show i
+end
+"""))
 
 end


### PR DESCRIPTION
The check wasn't working as expected because

Union{Tuple{A},Tuple{B}} <: Tuple

Note: in principle, I guess, it should still be possible to figure out if a union of tuples types has all the tuples of the same length, this fix doesn't address that, it just fixes the MethodError.