### PR TITLE
convertmsgtojson() standard-linter-v2 message output fix

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -397,8 +397,8 @@ function convertmsgtojson(msgs, style, dict_data)
             push!(output, Dict("severity" => etype,
                                "location" => Dict("file" => file,
                                                    "position" => errorrange),
-                               "excerpt" => code,
-                               "description" => "$evar: $txt"))
+                               "excerpt" => "$evar: $txt",
+                               "description" => code))
 
         end
     end

--- a/test/server.jl
+++ b/test/server.jl
@@ -140,11 +140,11 @@ end
     @test results_array[1]["source"] == "Lint.jl"
 
     results_array = writeandreadserver(pipe_slv2, json_input1)
-    @test results_array[1]["description"] == "something: use of undeclared symbol"
+    @test results_array[1]["description"] == "E321"
     @test results_array[1]["location"]["file"] == "none"
     @test results_array[1]["location"]["position"] == Array[[0, 0], [0, 80]]
     @test results_array[1]["severity"] == "error"
-    @test results_array[1]["excerpt"] == "E321"
+    @test results_array[1]["excerpt"] == "something: use of undeclared symbol"
 
 
     json_input4 = Dict("file" => "none", "code_str" => "function a(b)\nend",


### PR DESCRIPTION
I had two fields in cross: excerpt <-> description. This need to be released before linter-julia moves to new linter version, which is much nicer than the current one. Anyway there are no rush, but this is more less patch (bug fix). 