### PR TITLE
Print non-message to STDERR to avoid confusing emacs.

### DIFF
--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -67,7 +67,7 @@ function processOneSig(s, typeHints)
         ditype = determineType(s.args[1].args[end])
         return (s.head, ditype)
     else
-        println("Lint doesn't understand " * string(s) * " as an argument")
+        println(STDERR, "Lint doesn't understand " * string(s) * " as an argument")
     end
 end
 


### PR DESCRIPTION
This isn't a real issue at all, just a nitpick, but I'm using STDOUT to communicate with a lint process, and printing non-json messages that aren't real lint messages makes the communication a little messier to parse—the output is no longer even valid json.