### PR TITLE
Fix Lint startup error on 0.6

### DIFF
--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -133,7 +133,7 @@ function parseDeprecate(ex, lineabs)
     end
 end
 
-function getFuncNameAndSig(callex::Expr, strict::Bool=true)
+function getFuncNameAndSig(callex::Expr)
     typeHints = Dict{Symbol, Any}()
     if typeof(callex.args[1])==Symbol || Meta.isexpr(callex.args[1], :(.))
         funcname = callex.args[1]
@@ -151,8 +151,6 @@ function getFuncNameAndSig(callex::Expr, strict::Bool=true)
         # these kinds of call overloads are hard to understand
         # so for now, just ignore them
         return (nothing, nothing)
-    elseif strict
-        error("invalid function format $callex")
     else
         return (nothing, nothing)
     end
@@ -191,7 +189,7 @@ end
 # returns nothing, or DeprecateInfo
 function functionIsDeprecated(callex::Expr)
     global deprecates
-    funcname, sig = getFuncNameAndSig(callex, false)
+    funcname, sig = getFuncNameAndSig(callex)
     if Meta.isexpr(funcname, :(.))
         funcname = funcname.args[2]
     end


### PR DESCRIPTION
Lint was being too picky at startup when trying to read deprecated.jl. We'll have to revisit this code later, but for now we should stop throwing an error when we see something we don't understand.

Ref https://github.com/JuliaLang/julia/pull/21428#issuecomment-296412440

I'll backport this to Lint 0.5, as the latest master may be a disruptive change.