### PR TITLE
Backports for Lint 0.5.1

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -397,8 +397,8 @@ function convertmsgtojson(msgs, style, dict_data)
             push!(output, Dict("severity" => etype,
                                "location" => Dict("file" => file,
                                                    "position" => errorrange),
-                               "excerpt" => code,
-                               "description" => "$evar: $txt"))
+                               "excerpt" => "$evar: $txt",
+                               "description" => code))
 
         end
     end

--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -133,7 +133,7 @@ function parseDeprecate(ex, lineabs)
     end
 end
 
-function getFuncNameAndSig(callex::Expr, strict::Bool=true)
+function getFuncNameAndSig(callex::Expr)
     typeHints = Dict{Symbol, Any}()
     if typeof(callex.args[1])==Symbol || Meta.isexpr(callex.args[1], :(.))
         funcname = callex.args[1]
@@ -151,8 +151,6 @@ function getFuncNameAndSig(callex::Expr, strict::Bool=true)
         # these kinds of call overloads are hard to understand
         # so for now, just ignore them
         return (nothing, nothing)
-    elseif strict
-        error("invalid function format $callex")
     else
         return (nothing, nothing)
     end
@@ -191,7 +189,7 @@ end
 # returns nothing, or DeprecateInfo
 function functionIsDeprecated(callex::Expr)
     global deprecates
-    funcname, sig = getFuncNameAndSig(callex, false)
+    funcname, sig = getFuncNameAndSig(callex)
     if Meta.isexpr(funcname, :(.))
         funcname = funcname.args[2]
     end

--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -67,7 +67,7 @@ function processOneSig(s, typeHints)
         ditype = determineType(s.args[1].args[end])
         return (s.head, ditype)
     else
-        println("Lint doesn't understand " * string(s) * " as an argument")
+        println(STDERR, "Lint doesn't understand " * string(s) * " as an argument")
     end
 end
 

--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -121,7 +121,7 @@ length(::Type) = Nullable{Int}()
 length{T<:Pair}(::Type{T}) = Nullable(2)
 
 if VERSION < v"0.6.0-dev.2123" # where syntax introduced by julia PR #18457
-    length{T<:Tuple}(::Type{T}) = if !(T <: DataType) || Core.Inference.isvatuple(T)
+    length{T<:Tuple}(::Type{T}) = if !isa(T, DataType) || Core.Inference.isvatuple(T)
         Nullable{Int}()
     else
         Nullable{Int}(Base.length(T.types))

--- a/src/statictype.jl
+++ b/src/statictype.jl
@@ -121,7 +121,7 @@ length(::Type) = Nullable{Int}()
 length{T<:Pair}(::Type{T}) = Nullable(2)
 
 if VERSION < v"0.6.0-dev.2123" # where syntax introduced by julia PR #18457
-    length{T<:Tuple}(::Type{T}) = if Core.Inference.isvatuple(T)
+    length{T<:Tuple}(::Type{T}) = if !(T <: DataType) || Core.Inference.isvatuple(T)
         Nullable{Int}()
     else
         Nullable{Int}(Base.length(T.types))

--- a/test/bugs.jl
+++ b/test/bugs.jl
@@ -57,13 +57,21 @@ x, y = error()
 """)) == Set([:E539])
 
 # bug 166
-@test isempty(messageset(lintstr("""
+@test isempty(lintstr("""
 let x = :(type X end); x; end
-""")))
+"""))
 
 # bug 164
 @test messageset(lintstr("""
 undefined()
 """)) == Set([:E321])
+
+# bug 215
+@test isempty(lintstr("""
+x = (rand(Bool) ? (1,) : (1.0,),)
+for (i,) in x
+    @show i
+end
+"""))
 
 end

--- a/test/server.jl
+++ b/test/server.jl
@@ -140,11 +140,11 @@ end
     @test results_array[1]["source"] == "Lint.jl"
 
     results_array = writeandreadserver(pipe_slv2, json_input1)
-    @test results_array[1]["description"] == "something: use of undeclared symbol"
+    @test results_array[1]["description"] == "E321"
     @test results_array[1]["location"]["file"] == "none"
     @test results_array[1]["location"]["position"] == Array[[0, 0], [0, 80]]
     @test results_array[1]["severity"] == "error"
-    @test results_array[1]["excerpt"] == "E321"
+    @test results_array[1]["excerpt"] == "something: use of undeclared symbol"
 
 
     json_input4 = Dict("file" => "none", "code_str" => "function a(b)\nend",


### PR DESCRIPTION
This backports some smaller, independent minor fixes to 0.5. I will tag 0.6 once the n-pass linter is done; having this release is useful in the interim and in case 0.6 breaks some user code, as it's a disruptive change.