### PR TITLE
Do not initialize deprecation data if impossible

### DIFF
--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -10,7 +10,11 @@ end
 const deprecates = Dict{Symbol, Vector{DeprecateInfo}}()
 
 function initDeprecateInfo()
-    str = open(readstring, Base.find_source_file("deprecated.jl"))
+    sf = Base.find_source_file("deprecated.jl")
+    if sf === nothing
+        return
+    end
+    str = open(readstring, sf)
     linecharc = cumsum(map(x->length(x)+1, @compat(split(str, "\n", keep=true))))
 
     i = start(str)


### PR DESCRIPTION
Fix #229.

From what I can tell, source is not available on all installation, so we cannot figure out the deprecation data this way if it's not available.

(This will be backported to 0.5.2 because 0.6 is not ready for tagging yet.)