### PR TITLE
Remove Compat.rewrite_dict import test

### DIFF
--- a/test/import.jl
+++ b/test/import.jl
@@ -11,13 +11,6 @@ importall Lint
 msgs = lintstr(s)
 @test isempty(msgs)
 
-s = """
-import Compat
-f = Compat.rewrite_dict(:(a=b))
-"""
-msgs = lintstr(s)
-@test isempty(msgs)
-
 # Avoid warning users about dynamic includes.
 s = """
 script = \"test.jl\"; include(script)


### PR DESCRIPTION
This test is not particularly useful, especially since Compat has been updated to remove rewrite_dict.