### PR TITLE
Test on 0.6 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
     - osx
 julia:
     - 0.5
+    - 0.6
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
Updates Travis to test on 0.6 too.

I think it's time to tag a final release for 0.5 users, and then remove support for 0.5 and focus on the future.