### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/knowndeprec.jl
+++ b/src/knowndeprec.jl
@@ -4,7 +4,7 @@
 type DeprecateInfo
     funcname::Any
     sig::Union{Void, Array{Any,1}}
-    message::Compat.UTF8String
+    message::Compat.String
     line::Int
 end
 const deprecates = Dict{Symbol, Vector{DeprecateInfo}}()

--- a/src/server.jl
+++ b/src/server.jl
@@ -82,7 +82,7 @@ function readandwritethestream(conn,style)
         # println("file: ", file)
         code_len = parse(Int, readline(conn))
         # println("Code bytes: ", code_len)
-        code = Compat.UTF8String(read(conn, code_len))
+        code = Compat.String(read(conn, code_len))
         # println("Code received")
         # Do the linting
         msgs = lintfile(file, code)

--- a/test/strings.jl
+++ b/test/strings.jl
@@ -35,7 +35,7 @@ end
 """
 msgs = lintstr(s)
 @test msgs[1].code == :I271
-@test contains(msgs[1].message, "typeof(b) == $(Compat.ASCIIString)")
+@test contains(msgs[1].message, "typeof(b) == $(Compat.String)")
 
 u = """
 안녕하세요 = "Hello World"


### PR DESCRIPTION
Found some `Compat.UTF8String` and `Compat.ASCIIString`, fixed.