### PR TITLE
fixed julia 1.0 incompatibilities

### DIFF
--- a/src/cli.jl
+++ b/src/cli.jl
@@ -52,11 +52,10 @@ function lintpkgforfile(path::AbstractString, ctx::LintContext=LintContext())
 end
 
 function lintfile(f::AbstractString)
-    if !ispath(f)
+    if !isfile(f)
         throw("no such file exists")
     end
-    str = open(readstring, f)
-    lintfile(f, str)
+    lintfile(f, read(f, String))
 end
 
 function lintfile(f::AbstractString, code::AbstractString)

--- a/src/include.jl
+++ b/src/include.jl
@@ -12,9 +12,9 @@ function lintinclude(ctx::LintContext, f::AbstractString)
         end
 
         oldloc = location(ctx)
-        str = open(readstring, f)
+        str = read(f, String)
         location!(ctx, Location(f, 1))
-        
+
         # TODO: make sure to perform the include at top level
         _lintstr(str, ctx)
 

--- a/src/result.jl
+++ b/src/result.jl
@@ -21,7 +21,7 @@ function Base.show(io::IO, res::LintResult)
 end
 function Base.show(io::IO, ::MIME"text/plain", res::LintResult)
     for m in res.messages
-        Base.println_with_color(LINT_RESULT_COLORS[level(m)], io, string(m))
+        Base.printstyled(io, string(m), color = LINT_RESULT_COLORS[level(m)])
     end
 end
 

--- a/test/undeclare.jl
+++ b/test/undeclare.jl
@@ -70,7 +70,7 @@ end
 else
 s = """
 function f()
-    open(readstring, "tmp.txt")
+    read("tmp.txt", String)
 end
 """
 end


### PR DESCRIPTION
1) `open(readstring, f)` replaced by `read(f, String)`
2) `Base.println_with_color` replaced by `Base.printstyled`