### PR TITLE
Import `Sockets` to use `listen`.

### DIFF
--- a/src/Lint.jl
+++ b/src/Lint.jl
@@ -8,6 +8,7 @@ using Compat: TypeUtils, readline
 using JSON
 using AutoHashEquals
 using Printf
+using Sockets
 
 if isdefined(Base, :unwrap_unionall)
     using Base: unwrap_unionall


### PR DESCRIPTION
Closes #257.
Function `lintserver` in `server.jl` uses `listen`, which is now in `Sockets` and need to be improted.